### PR TITLE
Store/cache page IDs to speed up queries

### DIFF
--- a/app/DoctrineMigrations/Version20181121161847.php
+++ b/app/DoctrineMigrations/Version20181121161847.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20181121161847 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE event_wiki ADD ew_pages BLOB DEFAULT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE event_wiki DROP ew_pages');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "ext-PDO": "*",
         "ext-json": "*",
         "ext-apcu": "*",
+        "ext-bz2": "*",
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/doctrine-migrations-bundle": "^1.0",
         "doctrine/orm": "^2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b851700d9bf869eeabb1d8ac2ca73c8d",
+    "content-hash": "85c4196ba09c90d2afd56ba01860b631",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -218,16 +218,16 @@
         },
         {
             "name": "doctrine/common",
-            "version": "v2.9.0",
+            "version": "v2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/common.git",
-                "reference": "a210246d286c77d2b89040f8691ba7b3a713d2c1"
+                "reference": "30e33f60f64deec87df728c02b107f82cdafad9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/common/zipball/a210246d286c77d2b89040f8691ba7b3a713d2c1",
-                "reference": "a210246d286c77d2b89040f8691ba7b3a713d2c1",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/30e33f60f64deec87df728c02b107f82cdafad9d",
+                "reference": "30e33f60f64deec87df728c02b107f82cdafad9d",
                 "shasum": ""
             },
             "require": {
@@ -237,7 +237,7 @@
                 "doctrine/event-manager": "^1.0",
                 "doctrine/inflector": "^1.0",
                 "doctrine/lexer": "^1.0",
-                "doctrine/persistence": "^1.0",
+                "doctrine/persistence": "^1.1",
                 "doctrine/reflection": "^1.0",
                 "php": "^7.1"
             },
@@ -250,7 +250,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.9.x-dev"
+                    "dev-master": "2.10.x-dev"
                 }
             },
             "autoload": {
@@ -288,16 +288,14 @@
                     "email": "ocramius@gmail.com"
                 }
             ],
-            "description": "Common Library for Doctrine projects",
-            "homepage": "https://www.doctrine-project.org",
+            "description": "PHP Doctrine Common project is a library that provides additional functionality that other Doctrine projects depend on such as better reflection support, persistence interfaces, proxies, event system and much more.",
+            "homepage": "https://www.doctrine-project.org/projects/common.html",
             "keywords": [
-                "annotations",
-                "collections",
-                "eventmanager",
-                "persistence",
-                "spl"
+                "common",
+                "doctrine",
+                "php"
             ],
-            "time": "2018-07-12T21:16:12+00:00"
+            "time": "2018-11-21T01:24:55+00:00"
         },
         {
             "name": "doctrine/dbal",
@@ -940,16 +938,16 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "v2.6.2",
+            "version": "v2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/doctrine2.git",
-                "reference": "d2b4dd71d2a276edd65d0c170375b445f8a4a4a8"
+                "reference": "434820973cadf2da2d66e7184be370084cc32ca8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/doctrine2/zipball/d2b4dd71d2a276edd65d0c170375b445f8a4a4a8",
-                "reference": "d2b4dd71d2a276edd65d0c170375b445f8a4a4a8",
+                "url": "https://api.github.com/repos/doctrine/doctrine2/zipball/434820973cadf2da2d66e7184be370084cc32ca8",
+                "reference": "434820973cadf2da2d66e7184be370084cc32ca8",
                 "shasum": ""
             },
             "require": {
@@ -1018,20 +1016,20 @@
                 "database",
                 "orm"
             ],
-            "time": "2018-07-12T20:47:13+00:00"
+            "time": "2018-11-20T23:46:46+00:00"
         },
         {
             "name": "doctrine/persistence",
-            "version": "v1.0.1",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/persistence.git",
-                "reference": "af1ec238659a83e320f03e0e454e200f689b4b97"
+                "reference": "c0f1c17602afc18b4cbd8e1c8125f264c9cf7d38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/persistence/zipball/af1ec238659a83e320f03e0e454e200f689b4b97",
-                "reference": "af1ec238659a83e320f03e0e454e200f689b4b97",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/c0f1c17602afc18b4cbd8e1c8125f264c9cf7d38",
+                "reference": "c0f1c17602afc18b4cbd8e1c8125f264c9cf7d38",
                 "shasum": ""
             },
             "require": {
@@ -1043,17 +1041,17 @@
                 "php": "^7.1"
             },
             "conflict": {
-                "doctrine/common": "<2.9@dev"
+                "doctrine/common": "<2.10@dev"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^4.0",
+                "doctrine/coding-standard": "^5.0",
                 "phpstan/phpstan": "^0.8",
                 "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -1091,12 +1089,16 @@
                     "email": "ocramius@gmail.com"
                 }
             ],
-            "description": "Doctrine Persistence abstractions.",
+            "description": "The Doctrine Persistence project is a set of shared interfaces and functionality that the different Doctrine object mappers share.",
             "homepage": "https://doctrine-project.org/projects/persistence.html",
             "keywords": [
+                "mapper",
+                "object",
+                "odm",
+                "orm",
                 "persistence"
             ],
-            "time": "2018-07-12T12:37:50+00:00"
+            "time": "2018-11-21T00:33:13+00:00"
         },
         {
             "name": "doctrine/reflection",
@@ -2802,16 +2804,16 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "v4.1.7",
+            "version": "v4.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "b5c6892911fc7454a76528cb0d4d1af4336c7413"
+                "reference": "231050f83af3460c743f4d34c3b89308bf6272d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/b5c6892911fc7454a76528cb0d4d1af4336c7413",
-                "reference": "b5c6892911fc7454a76528cb0d4d1af4336c7413",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/231050f83af3460c743f4d34c3b89308bf6272d2",
+                "reference": "231050f83af3460c743f4d34c3b89308bf6272d2",
                 "shasum": ""
             },
             "require": {
@@ -2951,7 +2953,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2018-11-03T11:11:34+00:00"
+            "time": "2018-11-26T14:52:31+00:00"
         },
         {
             "name": "symfony/webpack-encore-pack",
@@ -3268,16 +3270,16 @@
         },
         {
             "name": "doctrine/doctrine-fixtures-bundle",
-            "version": "3.0.2",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/DoctrineFixturesBundle.git",
-                "reference": "7fc29d2b18c61ed99826b21fbfd1ff9969cc2e7f"
+                "reference": "0438f8dd0a21bc5325c6be3ae0a09131815e10d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/DoctrineFixturesBundle/zipball/7fc29d2b18c61ed99826b21fbfd1ff9969cc2e7f",
-                "reference": "7fc29d2b18c61ed99826b21fbfd1ff9969cc2e7f",
+                "url": "https://api.github.com/repos/doctrine/DoctrineFixturesBundle/zipball/0438f8dd0a21bc5325c6be3ae0a09131815e10d4",
+                "reference": "0438f8dd0a21bc5325c6be3ae0a09131815e10d4",
                 "shasum": ""
             },
             "require": {
@@ -3288,7 +3290,8 @@
                 "symfony/framework-bundle": "^3.3|^4.0"
             },
             "require-dev": {
-                "symfony/phpunit-bridge": "^3.3"
+                "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^7.4",
+                "symfony/phpunit-bridge": "^3.4 || ^4.0"
             },
             "type": "symfony-bundle",
             "extra": {
@@ -3325,7 +3328,7 @@
                 "Fixture",
                 "persistence"
             ],
-            "time": "2017-12-04T20:26:38+00:00"
+            "time": "2018-11-26T19:40:34+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -4470,28 +4473,28 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "3.1.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+                "reference": "febd209a219cea7b56ad799b30ebbea34b71eb8f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/febd209a219cea7b56ad799b30ebbea34b71eb8f",
+                "reference": "febd209a219cea7b56ad799b30ebbea34b71eb8f",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.1"
+                "phpunit/phpunit": "^7.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -4516,7 +4519,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-07-01T08:51:00+00:00"
+            "time": "2018-11-25T09:31:21+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -5024,16 +5027,16 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v4.1.7",
+            "version": "v4.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "2474c5d4a5e3431fee2f6f0dddde9d34983d9ceb"
+                "reference": "473fb4544afff836f4d9877c4607efe46b94cea9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/2474c5d4a5e3431fee2f6f0dddde9d34983d9ceb",
-                "reference": "2474c5d4a5e3431fee2f6f0dddde9d34983d9ceb",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/473fb4544afff836f4d9877c4607efe46b94cea9",
+                "reference": "473fb4544afff836f4d9877c4607efe46b94cea9",
                 "shasum": ""
             },
             "require": {
@@ -5086,7 +5089,7 @@
             ],
             "description": "Symfony PHPUnit Bridge",
             "homepage": "https://symfony.com",
-            "time": "2018-10-02T12:40:59+00:00"
+            "time": "2018-11-24T07:45:31+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -5188,7 +5191,8 @@
         "php": "^7.2",
         "ext-pdo": "*",
         "ext-json": "*",
-        "ext-apcu": "*"
+        "ext-apcu": "*",
+        "ext-bz2": "*"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/src/AppBundle/Model/Event.php
+++ b/src/AppBundle/Model/Event.php
@@ -55,8 +55,7 @@ class Event
     ];
 
     /**
-     * This defines what metrics are available to what wiki families.
-     * '*' means all wikis are applicable.
+     * This defines what metrics are available to what wiki families. '*' means all wikis are applicable.
      */
     public const WIKI_FAMILY_METRIC_MAP = [
         '*' => ['edits', 'new-editors', 'retention'],
@@ -126,6 +125,7 @@ class Event
     /**
      * One Event has many EventWikis.
      * @ORM\OneToMany(targetEntity="EventWiki", mappedBy="event", orphanRemoval=true, cascade={"persist"})
+     * @ORM\OrderBy({"domain" = "ASC"})
      * @var Collection|EventWiki[] Wikis that this event takes place on.
      */
     protected $wikis;

--- a/src/AppBundle/Repository/EventCategoryRepository.php
+++ b/src/AppBundle/Repository/EventCategoryRepository.php
@@ -9,7 +9,6 @@ namespace AppBundle\Repository;
 
 use AppBundle\Model\EventCategory;
 use AppBundle\Model\EventWiki;
-use Doctrine\DBAL\Query\QueryBuilder;
 
 /**
  * An EventCategoryRepository supplies and fetches data for the EventCategory class.
@@ -31,11 +30,10 @@ class EventCategoryRepository extends Repository
      * Get the IDs of pages in the given categories.
      * @param string $dbName Database name such as 'enwiki_p'.
      * @param int[] $ids IDs of categories to fetch from.
-     * @param bool $queryBuilder Whether to return just the Doctrine query builder object.
      * @param int|null $limit Max number of pages. null for no limit, but only do this if used in a subquery.
-     * @return string[]|QueryBuilder Page IDs or the QueryBuilder object.
+     * @return int[]
      */
-    public function getPagesInCategories(string $dbName, array $ids, bool $queryBuilder = false, ?int $limit = 20000)
+    public function getPagesInCategories(string $dbName, array $ids, ?int $limit = 20000): array
     {
         $rqb = $this->getReplicaConnection()->createQueryBuilder();
         $rqb->select(['DISTINCT(cl_from)'])
@@ -50,11 +48,8 @@ class EventCategoryRepository extends Repository
             $rqb->setMaxResults($limit);
         }
 
-        if ($queryBuilder) {
-            return $rqb;
-        }
-
-        return $this->executeQueryBuilder($rqb)->fetchAll();
+        $result = $this->executeQueryBuilder($rqb)->fetchAll(\PDO::FETCH_COLUMN);
+        return $result ? array_map('intval', $result) : [];
     }
 
     /**

--- a/src/AppBundle/Repository/Repository.php
+++ b/src/AppBundle/Repository/Repository.php
@@ -329,6 +329,8 @@ abstract class Repository extends EntityRepository
     {
         if (null !== $suffix) {
             return $name.'_'.$suffix;
+        } elseif ('' === $suffix) {
+            return $name;
         }
 
         // For 'revision' and 'logging' tables (actually views) on the WMF replicas,

--- a/src/AppBundle/Twig/FormatExtension.php
+++ b/src/AppBundle/Twig/FormatExtension.php
@@ -84,7 +84,7 @@ class FormatExtension extends Extension
         $decimal = $this->numFormatter->getSymbol(NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
         $thousands = $this->numFormatter->getSymbol(NumberFormatter::GROUPING_SEPARATOR_SYMBOL);
 
-        $formatted = number_format($number, $decimals, $decimal, $thousands);
+        $formatted = number_format((float)$number, $decimals, $decimal, $thousands);
 
         // Remove trailing .0's (e.g. 40.00 -> 40).
         return preg_replace("/\\".$decimal."0+$/", '', $formatted);

--- a/tests/AppBundle/Controller/DatabaseAwareWebTestCase.php
+++ b/tests/AppBundle/Controller/DatabaseAwareWebTestCase.php
@@ -110,6 +110,23 @@ abstract class DatabaseAwareWebTestCase extends EventMetricsTestCase
                 echo "\n\n".$stacktrace->text();
             }
         }
+
+        // Avoid memory leaks.
+
+        if (isset($this->entityManager)) {
+            $this->entityManager->close();
+            $this->entityManager = null;
+        }
+        gc_collect_cycles();
+
+        // Remove properties defined during the test.
+        $refl = new \ReflectionObject($this);
+        foreach ($refl->getProperties() as $prop) {
+            if (!$prop->isStatic() && 0 !== strpos($prop->getDeclaringClass()->getName(), 'PHPUnit_')) {
+                $prop->setAccessible(true);
+                $prop->setValue($this, null);
+            }
+        }
     }
 
     /**

--- a/tests/AppBundle/Model/EventWikiTest.php
+++ b/tests/AppBundle/Model/EventWikiTest.php
@@ -133,4 +133,19 @@ class EventWikiTest extends EventMetricsTestCase
         })->toArray();
         static::assertEquals(['*.wikipedia', 'commons.wikimedia'], array_values($domains));
     }
+
+    /**
+     * Test methods involving page IDs.
+     */
+    public function testPages(): void
+    {
+        $wiki = new EventWiki($this->event, 'test.wikipedia');
+
+        // Basic setter/getter.
+        $wiki->setPages([1, 2, 3]);
+        static::assertEquals([1, 2, 3], $wiki->getPages());
+
+        $wiki->setPages(null);
+        static::assertEquals([], $wiki->getPages());
+    }
 }


### PR DESCRIPTION
This does not include logic to determine when the stored page IDs
should be used, or when they should be refreshed. Instead it regenerates
them every time stats are regenerated.

Other various code cleanup and minor bug fixes.

Bug: https://phabricator.wikimedia.org/T207989