### PR TITLE
Use constant to define what metrics should be shown in the interface

### DIFF
--- a/app/Resources/views/events/_stats_summary.html.twig
+++ b/app/Resources/views/events/_stats_summary.html.twig
@@ -3,7 +3,7 @@
         <h4>{{ msg('participants') }}</h4>
         <h3>{{ event.numParticipants|num_format }}</h3>
     </div>
-    {% for metric, offset in event.availableMetrics %}
+    {% for metric in event.visibleMetrics if metric in event.availableMetrics|keys %}
         {% set stat = event.getStatistic(metric) %}
         {% if stat is not empty %}
             <div class="text-center event-stats--tile">

--- a/app/Resources/views/events/_wiki_table.html.twig
+++ b/app/Resources/views/events/_wiki_table.html.twig
@@ -5,7 +5,7 @@
             <th class="col-lg-3"></th>
             {% set sortableMetrics = ['pages-created', 'pages-improved'] %}
             {% set columnCount = 1 %}
-            {% for metric, offset in availableMetrics %}
+            {% for metric in event.visibleMetrics if metric in availableMetrics|keys %}
                 {% if metric not in commonMetrics and event.statistic(metric) is not empty %}
                     {% set columnCount = columnCount + 1 %}
                     {% set stat = event.statistic(metric) %}

--- a/app/Resources/views/events/show.html.twig
+++ b/app/Resources/views/events/show.html.twig
@@ -78,7 +78,7 @@
                         <th scope="row">{{ msg('participants') }}:</th>
                         <td>{{ event.numParticipants }}</td>
                     </tr>
-                    {% for metric in commonMetrics %}
+                    {% for metric in event.visibleMetrics if metric in commonMetrics %}
                         {% set stat = event.statistic(metric) %}
                         <tr>
                             <th scope="row">

--- a/app/Resources/views/programs/index.html.twig
+++ b/app/Resources/views/programs/index.html.twig
@@ -38,10 +38,10 @@
                                 {{ msg('participants') }}
                             </div>
                         </th>
-                        {% for metric, offset in metrics %}
+                        {% for metric in visibleMetrics if metrics[metric] is defined %}
                             <th class="text-nowrap">
                                 <div class="sort-link sort-link--{{ metric }}" data-column="{{ metric }}">
-                                    {{ msg(metric, [offset]) }}
+                                    {{ msg(metric, [metrics[metric]]) }}
                                 </div>
                             </th>
                         {% endfor %}
@@ -63,7 +63,7 @@
                             <td class="sort-entry--participants text-nowrap" data-value="{{ numParticipants }}">
                                 {{ numParticipants|num_format }}
                             </td>
-                            {% for metric in metrics|keys %}
+                            {% for metric in visibleMetrics if metrics[metric] is defined %}
                                 <td class="sort-entry--{{ metric }} text-nowrap" data-value="{{ program.statistic(metric) }}">
                                     {{ (program.statistic(metric) is not empty ? program.statistic(metric)|num_format : '&ndash;')|raw }}
                                 </td>

--- a/app/Resources/views/programs/show.html.twig
+++ b/app/Resources/views/programs/show.html.twig
@@ -55,10 +55,10 @@
                                 {{ msg('participants') }}
                             </div>
                         </th>
-                        {% for metric, offset in metrics %}
+                        {% for metric in visibleMetrics if metrics[metric] is defined %}
                             <th class="text-nowrap">
                                 <div class="sort-link sort-link--{{ metric }}" data-column="{{ metric }}">
-                                    {{ msg(metric, [offset]) }}
+                                    {{ msg(metric, [metrics[metric]]) }}
                                 </div>
                             </th>
                         {% endfor %}
@@ -79,7 +79,7 @@
                             <td class="text-nowrap sort-entry--participants" data-value="{{ numParticipants }}">
                                 {{ numParticipants|num_format }}
                             </td>
-                            {% for metric, offset in metrics %}
+                            {% for metric in visibleMetrics if metrics[metric] is defined %}
                                 {% set stat = event.statistic(metric) %}
                                 <td class="text-nowrap sort-entry--{{ metric }} text-nowrap" data-value="{{ stat ? stat.value : -1 }}">
                                     {{ (stat ? stat.value|num_format : '&ndash;')|raw }}

--- a/src/AppBundle/Controller/ProgramController.php
+++ b/src/AppBundle/Controller/ProgramController.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace AppBundle\Controller;
 
 use AppBundle\Form\ProgramType;
+use AppBundle\Model\Event;
 use AppBundle\Model\Program;
 use AppBundle\Repository\OrganizerRepository;
 use AppBundle\Repository\ProgramRepository;
@@ -44,6 +45,7 @@ class ProgramController extends EntityController
             'programRepo' => $programRepo,
             'gmTitle' => 'my-programs',
             'metrics' => $organizerRepo->getUniqueMetrics($organizer),
+            'visibleMetrics' => Event::getVisibleMetrics(),
         ]);
     }
 
@@ -125,6 +127,7 @@ class ProgramController extends EntityController
             'program' => $this->program,
             'metrics' => $programRepo->getUniqueMetrics($this->program),
             'isOrganizer' => $this->authUserIsOrganizer($this->program),
+            'visibleMetrics' => Event::getVisibleMetrics(),
         ]);
     }
 

--- a/src/AppBundle/Model/Event.php
+++ b/src/AppBundle/Model/Event.php
@@ -39,8 +39,6 @@ class Event
      *
      * Keys are i18n message keys, values are the 'offset' values.
      *
-     * The order specified here is also the order it will appear in the interface.
-     *
      * @see EventProcessor
      * @see EventStat
      */
@@ -65,6 +63,22 @@ class Event
         'wikipedia' => ['pages-created', 'pages-improved'],
         'commons' => ['files-uploaded', 'file-usage'],
         'wikidata' => ['items-created', 'items-improved'],
+    ];
+
+    /**
+     * This defines what metrics are visible throughout the application,
+     * except for reports (which custom define what they include).
+     * The order specified here is also the order it will appear in the interface.
+     */
+    public const VISIBLE_METRICS = [
+        'new-editors',
+        'retention',
+        'pages-created',
+        'pages-improved',
+        'files-uploaded',
+        'file-usage',
+        'items-created',
+        'items-improved',
     ];
 
     /**

--- a/src/AppBundle/Model/Traits/EventStatTrait.php
+++ b/src/AppBundle/Model/Traits/EventStatTrait.php
@@ -124,6 +124,15 @@ trait EventStatTrait
     }
 
     /**
+     * Get the key names of the metrics that should be visible in the interface.
+     * @return string[]
+     */
+    public static function getVisibleMetrics(): array
+    {
+        return self::VISIBLE_METRICS;
+    }
+
+    /**
      * Get the date of the last time the EventStat's were refreshed.
      * @return DateTime|null
      */


### PR DESCRIPTION
This hides the "Edits" metric that was added with #140, bringing the
interface to what it is currently in production.

This commit does not use the VISIBLE_METRICS constant in the
downloadable reports and wikitext export.

Bug: https://phabricator.wikimedia.org/T207909