### PR TITLE
Remove trailing slash routes and fix tests

### DIFF
--- a/app/config/parameters-travis.yml.dist
+++ b/app/config/parameters-travis.yml.dist
@@ -36,9 +36,8 @@ parameters:
     oauth.key:                  ~
     oauth.secret:               ~
 
-    # Path from domain to get to the root of the app. On Toolforge for instance this is /eventmetrics
-    # Do not include a trailing slash.
-    app.root_path: ''
+    # URL of the root of the app. On VPS for instance this is 'https://eventmetrics.wmflabs.org'.
+    app.base_url: '/'
 
     # Number of revisions to show per page on the Event Data page.
     app.revisions_per_page: 100

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -36,9 +36,8 @@ parameters:
     oauth.key:                  ~
     oauth.secret:               ~
 
-    # Path from domain to get to the root of the app. On Toolforge for instance this is /eventmetrics
-    # Do not include a trailing slash.
-    app.root_path: ''
+    # URL of the root of the app. On VPS for instance this is 'https://eventmetrics.wmflabs.org'.
+    app.base_url: 'http://localhost:8000'
 
     # Number of revisions to show per page on the Event Data page.
     app.revisions_per_page: 100

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -38,7 +38,6 @@ class DefaultController extends Controller
     /**
      * Get the URL of a random background image.
      * @Route("/api/background/{windowSize}", name="BackgroundImage")
-     * @Route("/api/background/{windowSize}/", name="BackgroundImageSlash")
      * @param int $windowSize Device's screen size, so that we don't
      *   download imagery larger than what's necessary.
      * @return JsonResponse

--- a/src/AppBundle/Controller/EntityController.php
+++ b/src/AppBundle/Controller/EntityController.php
@@ -190,7 +190,7 @@ abstract class EntityController extends Controller
     }
 
     /**
-     * Redirect to /login if the user is logged out.
+     * Redirect to homepage if the user is logged out, showing an error message that they need to login.
      * @throws HttpException
      */
     private function validateUser(): void
@@ -199,12 +199,11 @@ abstract class EntityController extends Controller
             return;
         }
         $this->addFlashMessage('danger', 'please-login');
-        $rootPath = $this->container->getParameter('app.root_path');
         throw new HttpException(
             Response::HTTP_TEMPORARY_REDIRECT,
             null,
             null,
-            ['Location' => $rootPath]
+            ['Location' => $this->container->getParameter('app.base_url')]
         );
     }
 }

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -31,7 +31,6 @@ class EventController extends EntityController
     /**
      * There is no list of events without a program to go with it.
      * @Route("/events", name="Events")
-     * @Route("/events/", name="EventsSlash")
      * @return RedirectResponse
      */
     public function indexAction(): RedirectResponse
@@ -42,7 +41,6 @@ class EventController extends EntityController
     /**
      * Show a form to create a new event.
      * @Route("/programs/{programId}/events/new", name="NewEvent")
-     * @Route("/programs/{programId}/events/new/", name="NewEventSlash")
      * @param Event $event Event to copy.
      * @return Response|RedirectResponse
      */
@@ -74,7 +72,6 @@ class EventController extends EntityController
     /**
      * Show a form to edit the given event.
      * @Route("/programs/{programId}/events/{eventId}/edit", name="EditEvent")
-     * @Route("/programs/{programId}/events/{eventId}/edit/", name="EditEventSlash")
      * @return Response|RedirectResponse
      */
     public function editAction(): Response
@@ -105,7 +102,6 @@ class EventController extends EntityController
      * Copy the given Event and redirect to the NewEvent action, clearing out the title,
      * and getting new instances of associated entities.
      * @Route("/programs/{programId}/events/{eventId}/copy", name="CopyEvent")
-     * @Route("/programs/{programId}/events/{eventId}/copy/", name="CopyEventSlash")
      * @return Response|RedirectResponse
      */
     public function copyAction(): Response
@@ -142,7 +138,6 @@ class EventController extends EntityController
     /**
      * Delete an event.
      * @Route("/programs/{programId}/events/{eventId}/delete", name="DeleteEvent")
-     * @Route("/programs/{programId}/events/{eventId}/delete/", name="DeleteEventSlash")
      * @return RedirectResponse
      */
     public function deleteAction(): RedirectResponse
@@ -166,10 +161,6 @@ class EventController extends EntityController
      * Show a specific event.
      * @Route("/programs/{programId}/events/{eventId}", name="Event")
      * @Route("/programs/{programId}/{eventId}", name="EventLegacy", requirements={
-     *     "eventId" = "^(?!(new|edit|delete|revisions)$)[^\/]+"
-     * })
-     * @Route("/programs/{programId}/events/{eventId}/", name="EventSlash")
-     * @Route("/programs/{programId}/{eventId}/", name="EventLegacySlash", requirements={
      *     "eventId" = "^(?!(new|edit|delete|revisions)$)[^\/]+"
      * })
      * @param EventRepository $eventRepo

--- a/src/AppBundle/Controller/EventDataController.php
+++ b/src/AppBundle/Controller/EventDataController.php
@@ -33,8 +33,6 @@ class EventDataController extends EntityController
      * Lists individual revisions that make up the Event.
      * @Route("/programs/{programId}/events/{eventId}/revisions", name="Revisions")
      * @Route("/programs/{programId}/{eventId}/revisions", name="RevisionsLegacy")
-     * @Route("/programs/{programId}/{eventId}/revisions/", name="RevisionsSlash")
-     * @Route("/programs/{programId}/events/{eventId}/revisions/", name="RevisionsSlashLegacy")
      * @param EventRepository $eventRepo
      * @param JobHandler $jobHandler
      * @return Response
@@ -119,7 +117,6 @@ class EventDataController extends EntityController
      * If there is quota, the job will be ran immediately and the results returned as JSON.
      * Otherwise, a job is created and it will later be ran via cron.
      * @Route("/events/process/{eventId}", name="EventProcess", requirements={"id" = "\d+"})
-     * @Route("/events/process/{eventId}/", name="EventProcessSlash", requirements={"id" = "\d+"})
      * @param JobHandler $jobHandler The job handler service, provided by Symfony dependency injection.
      * @param int $eventId The ID of the event to process.
      * @param EventRepository $eventRepo

--- a/src/AppBundle/Controller/ProgramController.php
+++ b/src/AppBundle/Controller/ProgramController.php
@@ -25,7 +25,6 @@ class ProgramController extends EntityController
     /**
      * Display a list of the programs.
      * @Route("/programs", name="Programs")
-     * @Route("/programs/", name="ProgramsSlash")
      * @param ProgramRepository $programRepo
      * @param OrganizerRepository $organizerRepo
      * @return Response
@@ -52,7 +51,6 @@ class ProgramController extends EntityController
     /**
      * Show a form to create a new program.
      * @Route("/programs/new", name="NewProgram")
-     * @Route("/programs/new/", name="NewProgramSlash")
      * @return Response|RedirectResponse
      */
     public function newAction(): Response
@@ -77,7 +75,6 @@ class ProgramController extends EntityController
     /**
      * Show a form to edit the given program.
      * @Route("/programs/{programId}/edit", name="EditProgram")
-     * @Route("/programs/{programId}/edit/", name="EditProgramSlash")
      * @return Response|RedirectResponse
      */
     public function editAction(): Response
@@ -100,7 +97,6 @@ class ProgramController extends EntityController
     /**
      * Delete a program.
      * @Route("/programs/{programId}/delete", name="DeleteProgram")
-     * @Route("/programs/{programId}/delete/", name="DeleteProgramSlash")
      * @return RedirectResponse
      */
     public function deleteAction(): RedirectResponse
@@ -117,7 +113,6 @@ class ProgramController extends EntityController
     /**
      * Show a specific program, listing all of its events.
      * @Route("/programs/{programId}", name="Program")
-     * @Route("/programs/{programId}/", name="ProgramSlash")
      * @param ProgramRepository $programRepo
      * @return Response
      */

--- a/tests/AppBundle/Controller/EventControllerTest.php
+++ b/tests/AppBundle/Controller/EventControllerTest.php
@@ -83,12 +83,10 @@ class EventControllerTest extends DatabaseAwareWebTestCase
             "/programs/$programId/events/$eventId/edit",
         ];
 
+        $this->client->followRedirects();
         foreach ($validRoutes as $route) {
             $this->client->request('GET', $route);
-            static::assertTrue(
-                $this->client->getResponse()->isSuccessful() || $this->client->getResponse()->isRedirect(),
-                "Not found: $route"
-            );
+            static::assertTrue($this->client->getResponse()->isSuccessful(), "Not found: $route");
         }
     }
 
@@ -127,18 +125,15 @@ class EventControllerTest extends DatabaseAwareWebTestCase
      */
     public function testLoggedOut(): void
     {
-        $this->addFixture(new LoadFixtures());
-        $this->executeFixtures();
-
-        /** @var Program $program */
-        $program = $this->entityManager
-            ->getRepository('Model:Program')
-            ->findOneBy(['title' => 'My_fun_program']);
-        $this->programId = $program->getId();
-
-        $this->crawler = $this->client->request('GET', $this->getProgramUrl());
+        $this->crawler = $this->client->request('GET', '/programs');
         $this->response = $this->client->getResponse();
-        static::assertEquals(307, $this->response->getStatusCode());
+        static::assertTrue($this->response->isRedirect());
+
+        $this->crawler = $this->client->followRedirect();
+        static::assertContains(
+            'Please login to continue',
+            $this->crawler->filter('.splash-dialog')->text()
+        );
     }
 
     /**

--- a/tests/AppBundle/Controller/EventDataControllerTest.php
+++ b/tests/AppBundle/Controller/EventDataControllerTest.php
@@ -11,7 +11,6 @@ use AppBundle\DataFixtures\ORM\LoadFixtures;
 use AppBundle\Model\Event;
 use AppBundle\Model\EventCategory;
 use AppBundle\Model\Job;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * Integration/functional tests for the EventDataController.


### PR DESCRIPTION
In Symfony 4 trailing slashes automatically redirect to the same route
without the slash. In Symfony 4.1.9 something else changed that caused
our manually added trailing slash routes to fail.

This commit removes all trailing slash routes and fixes the integration
tests accordingly.