### PR TITLE
Include the host and URI in error reports

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -52,6 +52,9 @@ services:
             - { name: kernel.event_listener, event: kernel.exception }
         arguments: ['@templating', '@logger', '%kernel.environment%']
 
+    AppBundle\Logger\WebRequestProcessor:
+        tags: { name: monolog.processor }
+
     AppBundle\Repository\:
         resource: '../../src/AppBundle/Repository/*'
         arguments: ['@doctrine.orm.entity_manager']

--- a/src/AppBundle/Logger/WebRequestProcessor.php
+++ b/src/AppBundle/Logger/WebRequestProcessor.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * This file contains only the WebProcessorMonolog class.
+ */
+
+declare(strict_types=1);
+
+namespace AppBundle\Logger;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * WebProcessorMonolog extends information included in error reporting.
+ */
+class WebRequestProcessor
+{
+    /** @var RequestStack The request stack. */
+    private $requestStack;
+
+    /**
+     * WebProcessorMonolog constructor.
+     * @param RequestStack $requestStack
+     */
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * Adds extra information to the log entry.
+     * @see https://symfony.com/doc/current/logging/processors.html
+     * @param array $record
+     * @return array
+     */
+    public function __invoke(array $record): array
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if ($request) {
+            $record['extra']['host'] = $request->getHost();
+            $record['extra']['uri'] = $request->getUri();
+        }
+
+        return $record;
+    }
+}


### PR DESCRIPTION
By defualt the error reports only include the exception info, time,
among other basic things. We want the URI especially so we can more
easily diagnose what went wrong.

This host is included to distinguish production errors from staging.