### PR TITLE
Remove null possibility for database names

### DIFF
--- a/src/AppBundle/Repository/EventCategoryRepository.php
+++ b/src/AppBundle/Repository/EventCategoryRepository.php
@@ -60,7 +60,12 @@ class EventCategoryRepository extends Repository
      */
     public function getCategoryId(string $domain, string $title): ?int
     {
-        // First get the database name.
+        // If no domain provided, no category can have an ID.
+        if (empty($domain)) {
+            return null;
+        }
+
+        // Get the database name.
         $ewRepo = $this->em->getRepository(EventWiki::class);
         $ewRepo->setContainer($this->container);
         $dbName = $ewRepo->getDbNameFromDomain($domain);


### PR DESCRIPTION
The EventWikiRepository::getDbNameFromDomain method was saying
it could return null, but that should never happen. It's better
to throw an exception here (which should also never happen) so
that users of this method can rely on what they get.

This also seems to be what Scrutinizer wants. :-)