### PR TITLE
Prevent empty page IDs when decompressing bzcompressed data

### DIFF
--- a/src/AppBundle/Model/EventWiki.php
+++ b/src/AppBundle/Model/EventWiki.php
@@ -321,7 +321,8 @@ class EventWiki
             ? stream_get_contents($this->$propertyName)
             : $this->$propertyName;
 
-        return explode(',', bzdecompress($blob));
+        // Decompressing the empty string or null results in an empty string, so array_filter removes this.
+        return array_filter(explode(',', bzdecompress($blob)));
     }
 
     /**
@@ -341,6 +342,13 @@ class EventWiki
             $this->$propertyName = null;
             return;
         }
-        $this->$propertyName = bzcompress(implode(',', $ids));
+        $filteredIds = array_filter($ids, function ($id) {
+            if (!is_numeric($id)) {
+                // Will be filtered out.
+                return null;
+            }
+            return (int)$id;
+        });
+        $this->$propertyName = bzcompress(implode(',', $filteredIds));
     }
 }

--- a/tests/AppBundle/Model/EventWikiTest.php
+++ b/tests/AppBundle/Model/EventWikiTest.php
@@ -147,5 +147,11 @@ class EventWikiTest extends EventMetricsTestCase
         $wiki->setPagesEdited([4, 5, 6]);
         static::assertEquals([4, 5, 6], $wiki->getPagesEdited());
         static::assertEquals([1, 2, 3, 4, 5, 6], $wiki->getPages());
+
+        // Make sure that empty strings are removed, and strings are cast to integers.
+        $wiki->setPagesCreated(['']);
+        static::assertEquals([], $wiki->getPagesCreated());
+        $wiki->setPagesCreated(['', '123', null, '', 456, 'foo']);
+        static::assertEquals([123, 456], $wiki->getPagesCreated());
     }
 }


### PR DESCRIPTION
When we switched to two page ID columns the 2nd one is initally
populated with NULLs. When this is retrieved and decompressed
it results in an empty string, which was being passed through
in the pageIds arrays and breaking SQL.

This patch fixes it by removing any empty elements in the returned
array.

Bug: https://phabricator.wikimedia.org/T213230