### PR TITLE
Fix double logging; no emails in dev environment

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -146,32 +146,3 @@ toolforge:
         logged_in_user: '%app.logged_in_user%'
     intuition:
         domain: 'eventmetrics'
-
-monolog:
-    handlers:
-        main:
-            type: fingers_crossed
-            action_level: critical
-            handler: main_handler
-        main_handler:
-            type: group
-            members: [console, log_file, mailer]
-        console:
-            type: console
-            level: debug
-            process_psr_3_messages: false
-        log_file:
-            type: stream
-            level: info
-            path: '%kernel.logs_dir%/%kernel.environment%.log'
-        mailer:
-            type: deduplication
-            handler: swift
-        swift:
-            type: swift_mailer
-            level: critical
-            from_email: '%mailer.from_email%'
-            to_email: '%mailer.to_email%'
-            subject: 'EventMetrics error: %%message%%'
-            formatter: monolog.formatter.html
-            content_type: text/html

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -29,9 +29,6 @@ monolog:
             process_psr_3_messages: false
             host: 127.0.0.1:9911
 
-        # No email error reports on local. Comment out if you need to test this feature.
-        swift: ~
-
         # uncomment to get logging in your browser
         # you may have to allow bigger header sizes in your Web server configuration
         #firephp:

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -11,12 +11,27 @@ monolog:
     handlers:
         main:
             type: fingers_crossed
-            action_level: error
-            handler: nested
-        nested:
-            type: stream
-            path: '%kernel.logs_dir%/%kernel.environment%.log'
-            level: debug
+            action_level: critical
+            handler: main_handler
+        main_handler:
+            type: group
+            members: [console, log_file, mailer]
         console:
             type: console
+            level: debug
             process_psr_3_messages: false
+        log_file:
+            type: stream
+            level: info
+            path: '%kernel.logs_dir%/%kernel.environment%.log'
+        mailer:
+            type: deduplication
+            handler: swift
+        swift:
+            type: swift_mailer
+            level: critical
+            from_email: '%mailer.from_email%'
+            to_email: '%mailer.to_email%'
+            subject: 'EventMetrics error: %%message%%'
+            formatter: monolog.formatter.html
+            content_type: text/html


### PR DESCRIPTION
We had monolog configuration in both config.yml and the environment-
specific config (e.g. config_dev.yml). This made everything be logged
twice. This commit makes each environment config have its own monolog
configuration, which has the side effect of ensuring no emails are sent
in the dev environment.