### PR TITLE
Include local file uploads in addition to Commons

### DIFF
--- a/src/AppBundle/DataFixtures/ORM/extended.yml
+++ b/src/AppBundle/DataFixtures/ORM/extended.yml
@@ -37,3 +37,8 @@ AppBundle\Model\Participant:
         # Old editor, 3 items created in period, 5 improved.
         __construct: ['@event1']
         userId: 6398
+    JeBonSer:
+        # See https://en.wikipedia.org/w/index.php?title=Special:Contributions/JeBonSer&start=2018-06-10&end=2018-06-11
+        # Old editor, 2 pages created, 2 local uploads.
+        __construct: ['@event1']
+        userId: 10120606

--- a/src/AppBundle/Model/Event.php
+++ b/src/AppBundle/Model/Event.php
@@ -68,6 +68,8 @@ class Event
             'byte-difference',
             'pages-created-pageviews',
             'pages-improved-pageviews',
+            'files-uploaded',
+            'file-usage',
         ],
         'commons' => ['files-uploaded', 'file-usage'],
         'wikidata' => ['items-created', 'items-improved'],

--- a/src/AppBundle/Model/EventStat.php
+++ b/src/AppBundle/Model/EventStat.php
@@ -48,8 +48,6 @@ class EventStat
         'pages-improved',
         'pages-created-pageviews',
         'pages-improved-pageviews',
-
-        // For Commons
         'files-uploaded',
         'file-usage',
 

--- a/src/AppBundle/Model/EventWikiStat.php
+++ b/src/AppBundle/Model/EventWikiStat.php
@@ -35,9 +35,8 @@ class EventWikiStat
     use StatTrait;
 
     /**
-     * Allowed metric types. Keys are the i18n key for the metric, and is what
-     * is stored in the database. Values are the applicable wikis for that type
-     * of metric, with null meaning all wikis.
+     * Allowed metric types. Keys are the i18n key for the metric, and is what is stored in the database.
+     * Values are the applicable wikis for that type of metric, with null meaning all wikis.
      * @see StatTrait Shared methods that use this constant.
      */
     public const METRIC_TYPES = [
@@ -47,8 +46,6 @@ class EventWikiStat
         'pages-improved',
         'pages-created-pageviews',
         'pages-improved-pageviews',
-
-        // For Commons
         'files-uploaded',
         'file-usage',
 

--- a/tests/AppBundle/Command/ProcessEventCommandTest.php
+++ b/tests/AppBundle/Command/ProcessEventCommandTest.php
@@ -160,7 +160,7 @@ class ProcessEventCommandTest extends EventMetricsTestCase
     }
 
     /**
-     * Number of edits
+     * Number of edits.
      */
     private function editCountSpec(): void
     {
@@ -170,11 +170,11 @@ class ProcessEventCommandTest extends EventMetricsTestCase
                 'event' => $this->event,
                 'metric' => 'edits',
             ]);
-        static::assertEquals(18, $eventStat->getValue());
+        static::assertEquals(20, $eventStat->getValue());
     }
 
     /**
-     * Number of edits
+     * Bytes difference.
      */
     private function byteDifferenceSpec(): void
     {
@@ -184,7 +184,7 @@ class ProcessEventCommandTest extends EventMetricsTestCase
                 'wiki' => $this->event->getWikiByDomain('en.wikipedia'),
                 'metric' => 'byte-difference',
             ]);
-        static::assertEquals(4830, $eventWikiStat->getValue());
+        static::assertEquals(12806, $eventWikiStat->getValue());
 
         $eventStat = $this->entityManager
             ->getRepository('Model:EventStat')
@@ -192,7 +192,7 @@ class ProcessEventCommandTest extends EventMetricsTestCase
                 'event' => $this->event,
                 'metric' => 'byte-difference',
             ]);
-        static::assertEquals(4830, $eventStat->getValue());
+        static::assertEquals(12806, $eventStat->getValue());
     }
 
     /**
@@ -207,7 +207,7 @@ class ProcessEventCommandTest extends EventMetricsTestCase
                 'event' => $this->event,
                 'metric' => 'pages-created',
             ]);
-        static::assertEquals(1, $eventStat->getValue());
+        static::assertEquals(3, $eventStat->getValue());
 
         // As an EventWikiStat...
         $eventWikiStat = $this->entityManager
@@ -216,7 +216,7 @@ class ProcessEventCommandTest extends EventMetricsTestCase
                 'wiki' => $this->event->getWikiByDomain('en.wikipedia'),
                 'metric' => 'pages-created',
             ]);
-        static::assertEquals(1, $eventWikiStat->getValue());
+        static::assertEquals(3, $eventWikiStat->getValue());
     }
 
     /**
@@ -231,7 +231,7 @@ class ProcessEventCommandTest extends EventMetricsTestCase
                 'event' => $this->event,
                 'metric' => 'pages-improved',
             ]);
-        static::assertEquals(7, $eventStat->getValue());
+        static::assertEquals(9, $eventStat->getValue());
 
         $eventWikiStat = $this->entityManager
             ->getRepository('Model:EventWikiStat')
@@ -239,7 +239,7 @@ class ProcessEventCommandTest extends EventMetricsTestCase
                 'wiki' => $this->event->getWikiByDomain('en.wikipedia'),
                 'metric' => 'pages-improved',
             ]);
-        static::assertEquals(7, $eventWikiStat->getValue());
+        static::assertEquals(9, $eventWikiStat->getValue());
     }
 
     /**
@@ -253,7 +253,7 @@ class ProcessEventCommandTest extends EventMetricsTestCase
                 'event' => $this->event,
                 'metric' => 'files-uploaded',
             ]);
-        static::assertEquals(1, $eventStat->getValue());
+        static::assertEquals(3, $eventStat->getValue());
 
         $eventWikiStat = $this->entityManager
             ->getRepository('Model:EventWikiStat')
@@ -262,6 +262,14 @@ class ProcessEventCommandTest extends EventMetricsTestCase
                 'metric' => 'files-uploaded',
             ]);
         static::assertEquals(1, $eventWikiStat->getValue());
+
+        $eventWikiStat = $this->entityManager
+            ->getRepository('Model:EventWikiStat')
+            ->findOneBy([
+                'wiki' => $this->event->getWikiByDomain('en.wikipedia'),
+                'metric' => 'files-uploaded',
+            ]);
+        static::assertEquals(2, $eventWikiStat->getValue());
     }
 
     /**
@@ -275,8 +283,10 @@ class ProcessEventCommandTest extends EventMetricsTestCase
                 'event' => $this->event,
                 'metric' => 'file-usage',
             ]);
-        // Used at least on [[Domino Park]], but there could eventually be others.
-        static::assertGreaterThan(0, $eventStat->getValue());
+
+        // Used on [[Domino Park]], [[As Long as It Matters]], and [[Need to Be Next to You]],
+        // but there could eventually be others.
+        static::assertGreaterThan(2, $eventStat->getValue());
 
         $eventWikiStat = $this->entityManager
             ->getRepository('Model:EventWikiStat')
@@ -285,6 +295,15 @@ class ProcessEventCommandTest extends EventMetricsTestCase
                 'metric' => 'file-usage',
             ]);
         static::assertGreaterThan(0, $eventWikiStat->getValue());
+
+        // Used on [[As Long as It Matters]] and [[Need to Be Next to You]], eventually there may be more.
+        $eventWikiStat = $this->entityManager
+            ->getRepository('Model:EventWikiStat')
+            ->findOneBy([
+                'wiki' => $this->event->getWikiByDomain('en.wikipedia'),
+                'metric' => 'file-usage',
+            ]);
+        static::assertGreaterThan(1, $eventWikiStat->getValue());
     }
 
     /**

--- a/tests/AppBundle/Controller/EventDataControllerTest.php
+++ b/tests/AppBundle/Controller/EventDataControllerTest.php
@@ -126,18 +126,24 @@ class EventDataControllerTest extends DatabaseAwareWebTestCase
         $this->response = $this->client->getResponse();
 
         // Exactly 31 edits.
-        static::assertEquals(31, $this->crawler->filter('.event-revision')->count());
+        static::assertEquals(33, $this->crawler->filter('.event-revision')->count());
 
-        // 12 edits to enwiki.
+        // 14 edits to enwiki.
         static::assertEquals(
-            12,
+            14,
             substr_count($this->response->getContent(), '<td class="text-nowrap">en.wikipedia</td>')
         );
 
-        // All are to [[Domino Park]].
+        // 12 are to [[Domino Park]].
         static::assertEquals(
             12,
             substr_count($this->response->getContent(), 'https://en.wikipedia.org/wiki/Domino Park')
+        );
+
+        // 3 are files.
+        static::assertEquals(
+            3,
+            substr_count($this->response->getContent(), '/wiki/File:')
         );
     }
 

--- a/tests/AppBundle/Model/EventTest.php
+++ b/tests/AppBundle/Model/EventTest.php
@@ -364,6 +364,8 @@ class EventTest extends EventMetricsTestCase
                 'pages-improved' => null,
                 'pages-created-pageviews' => null,
                 'pages-improved-pageviews' => 30,
+                'files-uploaded' => null,
+                'file-usage' => null,
             ],
             $event->getAvailableMetrics()
         );


### PR DESCRIPTION
This extends the current files-uploaded and file-usage metrics to be
computed on all content wikis and not just Commons.
    
Other very minor code and comment nitpicks.

Bug: https://phabricator.wikimedia.org/T206819