### PR TITLE
Fix datestamps in queries and display on Edit List page

### DIFF
--- a/app/Resources/views/events/_header.html.twig
+++ b/app/Resources/views/events/_header.html.twig
@@ -12,7 +12,7 @@
                     {% set statsDesc = '' %}
                 {% else %}
                     {% set statsBtnText = msg('update-data') %}
-                    {% set statsDesc = msg('last-updated', [event.updatedWithTimezone|date_localize]) ~ ' (' ~ event.displayTimezone ~ ')' %}
+                    {% set statsDesc = msg('last-updated', [event.updatedUTC|date_localize]) ~ ' (' ~ event.displayTimezone ~ ')' %}
                 {% endif %}
                 {% if job != false and (job.status == constant('STATUS_STARTED', job) or job.status == constant('STATUS_QUEUED', job)) %}
                     {% set statsBtnText = msg('updating') %}

--- a/app/Resources/views/events/event_summary.wikitext.twig
+++ b/app/Resources/views/events/event_summary.wikitext.twig
@@ -1,6 +1,6 @@
 {% import 'macros/wiki.html.twig' as wikiHelper %}
 === {{ msg('event-summary') }} &bull; {{ event.displayTitle }} ===
-<small>''Data snapshot as of {{ event.updatedWithTimezone|date_localize }} ({{ event.displayTimezone }})''
+<small>''Data snapshot as of {{ event.updatedUTC|date_localize }} ({{ event.displayTimezone }})''
 &bull; [https://meta.wikimedia.org/wiki/Event_Metrics/Definitions_of_metrics {{ msg('metrics-about-link') }}]</small>
 
 {| class="wikitable"

--- a/app/Resources/views/events/revisions.html.twig
+++ b/app/Resources/views/events/revisions.html.twig
@@ -57,7 +57,7 @@
                     <tr class="event-revision">
                         <td class="text-nowrap">
                             ({{ wiki.pageLink('Special:Diff/' ~ rev.id, rev.wiki, msg('diff')|lower) }})
-                            {{ wiki.pageLink('Special:PermaLink/' ~ rev.id, rev.wiki, rev.timestamp|date_localize) }}
+                            {{ wiki.pageLink('Special:PermaLink/' ~ rev.id, rev.wiki, rev.timestamp|date_localize(event.timezone)) }}
                         </td>
                         <td>
                             {# TODO: programatically fetch namespace name from meta API #}

--- a/app/Resources/views/events/show.html.twig
+++ b/app/Resources/views/events/show.html.twig
@@ -66,7 +66,7 @@
                     {% elseif event.numParticipants == 0 %}
                         {# FIXME: ^ also check for event.numCategories == 0 and add msg('categories') once T194707#4620358 is resolved #}
                         {{ msg('event-misconfig', [msg('participants')]) }}
-                    {% elseif event.startWithTimezone > date() %}
+                    {% elseif event.startUTC > date() %}
                         {{ msg('event-in-future') }}
                         (<a href="{{ path('EditEvent', {'programId': program.id, 'eventId': event.id}) }}">{{ msg('settings')|lower }}</a>)
                     {% else %}

--- a/src/AppBundle/DataFixtures/ORM/extended.yml
+++ b/src/AppBundle/DataFixtures/ORM/extended.yml
@@ -24,7 +24,7 @@ AppBundle\Model\EventWiki:
 AppBundle\Model\Participant:
     MusikAnimal:
         # See https://en.wikipedia.org/wiki/Special:Contribs/MusikAnimal?namespace=0&start=2018-06-10&end=2018-06-11
-        # Old editor, 5 edits in period, 1 page creation.
+        # Old editor, 5 pages improved, 1 page creation, 1 Commons upload.
         __construct: ['@event1']
         userId: 10584730
     SingleTransferrableNerd:
@@ -34,7 +34,7 @@ AppBundle\Model\Participant:
         userId: 54502394
     Samwilson:
         # See https://www.wikidata.org/wiki/Special:Contribs/Samwilson?namespace=0&start=2018-06-10&end=2018-06-11
-        # Old editor, 3 items created in period, 5 improved.
+        # Old editor, 3 items created in period, 5 improved. 1 more edit outside list, because we can't give Special:Contribs exact times.
         __construct: ['@event1']
         userId: 6398
     JeBonSer:

--- a/src/AppBundle/Model/Event.php
+++ b/src/AppBundle/Model/Event.php
@@ -179,7 +179,8 @@ class Event
      *     length=64,
      *     options={"default":"UTC"}
      * )
-     * @var string The end date and time of the the event.
+     * @var string The timezone of the Event. Should be a PHP-supported timezone.
+     * @see https://secure.php.net/manual/en/timezones.php
      */
     protected $timezone;
 
@@ -263,7 +264,7 @@ class Event
         return $this->wikis->count() > 0 &&
             null !== $this->start &&
             null !== $this->end &&
-            $this->getStartWithTimezone() < new DateTime() &&
+            $this->getStartUTC() < new DateTime() &&
             (
                 $this->participants->count() > 0
                 // FIXME: uncomment once issues at T194707#4620358 are resolved.
@@ -290,6 +291,7 @@ class Event
 
     /**
      * Get the start date of this Event.
+     * @see self::getStartUTC() if you need to use the datestamp in an SQL query.
      * @return DateTime|null
      */
     public function getStart(): ?DateTime
@@ -307,10 +309,10 @@ class Event
     }
 
     /**
-     * Get the start date adjusted with the Event's timezone.
+     * Get the start date in UTC. This is what should be used in SQL queries.
      * @return DateTime
      */
-    public function getStartWithTimezone(): DateTime
+    public function getStartUTC(): DateTime
     {
         $dateStr = $this->start->format('YmdHis');
         $dt = new DateTime($dateStr, new DateTimeZone($this->timezone));
@@ -320,6 +322,7 @@ class Event
 
     /**
      * Get the end date of this Event.
+     * @see self::getEndUTC() if you need to use the datestamp in an SQL query.
      * @return DateTime|null
      */
     public function getEnd(): ?DateTime
@@ -328,10 +331,10 @@ class Event
     }
 
     /**
-     * Get the end date adjusted with the Event's timezone.
+     * Get the end date in UTC. This is what should be used in SQL queries.
      * @return DateTime
      */
-    public function getEndWithTimezone(): DateTime
+    public function getEndUTC(): DateTime
     {
         $dateStr = $this->end->format('YmdHis');
         $dt = new DateTime($dateStr, new DateTimeZone($this->timezone));

--- a/src/AppBundle/Model/Traits/EventStatTrait.php
+++ b/src/AppBundle/Model/Traits/EventStatTrait.php
@@ -134,6 +134,7 @@ trait EventStatTrait
 
     /**
      * Get the date of the last time the EventStat's were refreshed.
+     * @see self::getUpdatedUTC() if you need to use the datestamp in an SQL query.
      * @return DateTime|null
      */
     public function getUpdated(): ?DateTime
@@ -142,10 +143,10 @@ trait EventStatTrait
     }
 
     /**
-     * Get the update at value adjusted with the Event's timezone.
+     * Get the updated at value as UTC. This is what should be used in SQL queries.
      * @return DateTime
      */
-    public function getUpdatedWithTimezone(): DateTime
+    public function getUpdatedUTC(): DateTime
     {
         $this->updated->setTimezone(new DateTimeZone($this->timezone));
         return new DateTime(

--- a/src/AppBundle/Repository/EventRepository.php
+++ b/src/AppBundle/Repository/EventRepository.php
@@ -40,7 +40,7 @@ class EventRepository extends Repository
     {
         $userIds = $event->getParticipantIds();
         $offset = Event::getAllAvailableMetrics()['new-editors'];
-        $start = (new DateTime($event->getStart()->format('YmdHis')))
+        $start = (new DateTime($event->getStartUTC()->format('YmdHis')))
             ->sub(new DateInterval('P'.$offset.'D'))
             ->format('YmdHis');
         $end = $event->getEnd()->format('YmdHis');
@@ -278,7 +278,7 @@ class EventRepository extends Repository
      * @param int|null $offset Number of rows to offset, used for pagination.
      * @param int|null $limit Number of rows to fetch.
      * @param bool $count Whether to get a COUNT instead of the actual revisions.
-     * @return int|string[] Count of revisions, or string array with keys 'id',
+     * @return int|mixed[] Count of revisions, or string array with keys 'id',
      *     'timestamp', 'page', 'wiki', 'username', 'summary'.
      */
     private function getRevisionsData(Event $event, ?int $offset, ?int $limit, bool $count)
@@ -299,8 +299,8 @@ class EventRepository extends Repository
             $sql .= "\nLIMIT $offset, $limit";
         }
 
-        $start = $event->getStart()->format('Ymd000000');
-        $end = $event->getEnd()->format('Ymd235959');
+        $start = $event->getStartUTC()->format('YmdHis');
+        $end = $event->getEndUTC()->format('YmdHis');
 
         $stmt = $this->executeReplicaQuery($sql, [
             'startDate' => $start,

--- a/src/AppBundle/Repository/EventWikiRepository.php
+++ b/src/AppBundle/Repository/EventWikiRepository.php
@@ -414,8 +414,8 @@ class EventWikiRepository extends Repository
         $res = $this->executeReplicaQueryWithTypes(
             $outerSql,
             [
-                'start' => $event->getStart()->format('YmdHis'),
-                'end' => $event->getEnd()->format('YmdHis'),
+                'start' => $event->getStartUTC()->format('YmdHis'),
+                'end' => $event->getEndUTC()->format('YmdHis'),
                 'pageIds' => $pageIds,
                 'usernames' => $usernames,
             ],

--- a/src/AppBundle/Service/EventProcessor.php
+++ b/src/AppBundle/Service/EventProcessor.php
@@ -223,7 +223,7 @@ class EventProcessor
         $ewRepo = $this->entityManager->getRepository('Model:EventWiki');
         $ewRepo->setContainer($this->container);
 
-        $start = $this->event->getStartWithTimezone();
+        $start = $this->event->getStartUTC();
         $pageviewsCreatedTotal = 0;
         $pageviewsImprovedTotal = 0;
         foreach ($this->event->getWikis() as $wiki) {
@@ -315,8 +315,8 @@ class EventProcessor
         $this->log("> Fetching pages created or improved on {$wiki->getDomain()}...");
 
         $dbName = $ewRepo->getDbNameFromDomain($wiki->getDomain());
-        $start = $this->event->getStartWithTimezone();
-        $end = $this->event->getEndWithTimezone();
+        $start = $this->event->getStartUTC();
+        $end = $this->event->getEndUTC();
         $usernames = $this->getParticipantNames();
         $categoryTitles = $this->event->getCategoryTitlesForWiki($wiki);
         $pageIdsCreated = $ewRepo->getPageIds($dbName, $start, $end, $usernames, $categoryTitles, 'created');
@@ -352,8 +352,8 @@ class EventProcessor
         $this->log("> Fetching files uploaded on {$wiki->getDomain()} and global file usage...");
 
         $dbName = $ewRepo->getDbNameFromDomain($wiki->getDomain());
-        $start = $this->event->getStartWithTimezone();
-        $end = $this->event->getEndWithTimezone();
+        $start = $this->event->getStartUTC();
+        $end = $this->event->getEndUTC();
 
         $ret = $this->eventRepo->getFilesUploaded($dbName, $start, $end, $this->getParticipantNames());
         $this->createOrUpdateEventWikiStat($wiki, 'files-uploaded', $ret);
@@ -374,8 +374,8 @@ class EventProcessor
         $this->log("> Fetching items created or improved on Wikidata...");
 
         $dbName = 'wikidatawiki_p';
-        $start = $this->event->getStartWithTimezone();
-        $end = $this->event->getEndWithTimezone();
+        $start = $this->event->getStartUTC();
+        $end = $this->event->getEndUTC();
         $usernames = $this->getParticipantNames();
         $categoryTitles = $this->event->getCategoryTitlesForWiki($wiki);
         $pageIdsCreated = $ewRepo->getPageIds($dbName, $start, $end, $usernames, $categoryTitles, 'created');
@@ -427,7 +427,7 @@ class EventProcessor
         $this->log("\nFetching retention...");
 
         $retentionOffset = Event::getAllAvailableMetrics()['retention'];
-        $end = $this->event->getEndWithTimezone()->modify("+$retentionOffset days");
+        $end = $this->event->getEndUTC()->modify("+$retentionOffset days");
 
         // Only calculate for new editors.
         $usernames = $this->getNewEditors();

--- a/src/AppBundle/Twig/FormatExtension.php
+++ b/src/AppBundle/Twig/FormatExtension.php
@@ -9,6 +9,7 @@ namespace AppBundle\Twig;
 
 use AppBundle\Repository\EventWikiRepository;
 use DateTime;
+use DateTimeZone;
 use IntlDateFormatter;
 use NumberFormatter;
 
@@ -93,14 +94,14 @@ class FormatExtension extends Extension
     /**
      * Localize the given date based on language settings.
      * @param string|DateTime $datetime
+     * @param string $timezone Convert the timestamp to the given timezone.
      * @return string
      */
-    public function dateFormat($datetime): string
+    public function dateFormat($datetime, string $timezone = 'UTC'): string
     {
-        // If the language is 'en' with no country code,
-        // override the US English format that's provided by ICU.
+        // If the language is 'en' with no country code, override the US English format that's provided by ICU.
         if ('en' === $this->intuition->getLang()) {
-            return $this->dateFormatStd($datetime);
+            return $this->dateFormatStd($datetime, $timezone);
         }
 
         // Otherwise, format it according to the current locale.
@@ -116,19 +117,24 @@ class FormatExtension extends Extension
             $datetime = new DateTime($datetime);
         }
 
+        $datetime->setTimezone(new DateTimeZone($timezone));
+
         return $this->dateFormatter->format($datetime);
     }
 
     /**
      * Format the given date to ISO 8601.
      * @param string|DateTime $datetime
+     * @param string $timezone Convert the timestamp to the given timezone.
      * @return string
      */
-    public function dateFormatStd($datetime): string
+    public function dateFormatStd($datetime, string $timezone = 'UTC'): string
     {
         if (is_string($datetime) || is_int($datetime)) {
             $datetime = new DateTime($datetime);
         }
+
+        $datetime->setTimezone(new DateTimeZone($timezone));
 
         return $datetime->format('Y-m-d H:i');
     }

--- a/tests/AppBundle/Controller/EventDataControllerTest.php
+++ b/tests/AppBundle/Controller/EventDataControllerTest.php
@@ -125,8 +125,8 @@ class EventDataControllerTest extends DatabaseAwareWebTestCase
         );
         $this->response = $this->client->getResponse();
 
-        // Exactly 31 edits.
-        static::assertEquals(33, $this->crawler->filter('.event-revision')->count());
+        // Exactly 33 edits.
+        static::assertEquals(34, $this->crawler->filter('.event-revision')->count());
 
         // 14 edits to enwiki.
         static::assertEquals(

--- a/tests/AppBundle/Model/EventTest.php
+++ b/tests/AppBundle/Model/EventTest.php
@@ -81,8 +81,8 @@ class EventTest extends EventMetricsTestCase
         );
         static::assertEquals(new DateTime('2017-01-01 16:00'), $event->getStart());
         static::assertEquals(new DateTime('2017-03-01 21:00'), $event->getEnd());
-        static::assertEquals(new DateTime('2017-01-01 21:00'), $event->getStartWithTimezone());
-        static::assertEquals(new DateTime('2017-03-02 02:00'), $event->getEndWithTimezone());
+        static::assertEquals(new DateTime('2017-01-01 21:00'), $event->getStartUTC());
+        static::assertEquals(new DateTime('2017-03-02 02:00'), $event->getEndUTC());
 
         // Date types reversed.
         $event2 = new Event(
@@ -320,7 +320,7 @@ class EventTest extends EventMetricsTestCase
         static::assertEquals($datetime, $event->getUpdated());
         static::assertEquals(
             new DateTime('2017-01-01 12:00'),
-            $event->getUpdatedWithTimezone()
+            $event->getUpdatedUTC()
         );
     }
 


### PR DESCRIPTION
Rename Event::getStartWithTimezone() (and related methods) to
getStartUTC(), to avoid confusion. This commit changes all queries to
use the UTC variant, as it should. In hindsight, we should have stored
datestamps in UTC and only converted for display purposes, but it's
perhaps too late for that.

Make sure the Edit List page shows timestamps in the event's timezone
and not UTC.

Tests were updated to account for the longstanding bugs of using the
non-UTC timestamps in SQL queries.

Other minor code cleanup.

Bug: T215926