### PR TITLE
Don't manually include participants as a stat, is done automatically

### DIFF
--- a/app/Resources/views/events/_participants.html.twig
+++ b/app/Resources/views/events/_participants.html.twig
@@ -78,10 +78,11 @@
     {% endif %}
 {% endset %}
 
+{# Here we use event.participants.count, ensuring it's the number of manually entered participants (and not derived). #}
 {{
     layout.panel(
         'participants',
-        event.numParticipants ~ ' ' ~ msg('num-participants', [event.numParticipants]),
+        event.participants.count ~ ' ' ~ msg('num-participants', [event.participants.count]),
         content
     )
 }}

--- a/app/Resources/views/events/event_summary.wikitext.twig
+++ b/app/Resources/views/events/event_summary.wikitext.twig
@@ -3,10 +3,7 @@
 <small>''{{ msg('last-updated', [event.updatedUTC|date_localize]) }} ({{ event.displayTimezone }})''
 &bull; [https://meta.wikimedia.org/wiki/Event_Metrics/Definitions_of_metrics {{ msg('metrics-about-link') }}]</small>
 
-{| class="wikitable"
-|-
-| {{ msg('participants') }}
-| {{ event.numParticipants }}{#-
+{| class="wikitable"{#-
 -#}{% for metric in ['participants', 'pages-created', 'pages-improved', 'byte-difference', 'files-uploaded', 'items-created', 'items-improved', 'pages-created-pageviews', 'pages-improved-pageviews-avg'] %}
 {% set stat = event.getStatistic(metric) %}
 {% if stat is not empty %}

--- a/app/Resources/views/events/show.html.twig
+++ b/app/Resources/views/events/show.html.twig
@@ -30,7 +30,7 @@
             {% if event.updated is not null %}
                 {% if event.wikis|length > 1 %}
                     <h2>{{ msg('statistics') }}</h2>
-                    {% set commonMetrics = ['new-editors', 'retention'] %}
+                    {% set commonMetrics = ['participants', 'new-editors', 'retention'] %}
                     <table class="event-metadata event-metadata--grouped">
                         {% for metric in event.visibleMetrics if metric in commonMetrics %}
                             {% set stat = event.statistic(metric) %}

--- a/app/Resources/views/programs/show.html.twig
+++ b/app/Resources/views/programs/show.html.twig
@@ -68,9 +68,6 @@
                                     {{ layout.actionButtons('Event', event, {'programId': program.id, 'eventId': event.id}, numParticipants == 0) }}
                                 </td>
                             {% endif %}
-                            <td class="text-nowrap sort-entry--participants" data-value="{{ numParticipants }}">
-                                {{ numParticipants|num_format }}
-                            </td>
                             {% for metric in visibleMetrics if metrics[metric] is defined %}
                                 {% set stat = event.statistic(metric) %}
                                 <td class="text-nowrap sort-entry--{{ metric }} text-nowrap" data-value="{{ stat ? stat.value : -1 }}">

--- a/src/AppBundle/Model/Event.php
+++ b/src/AppBundle/Model/Event.php
@@ -537,7 +537,10 @@ class Event
      */
     public function getNumParticipants(): int
     {
-        return $this->participants->count();
+        // Use the derived participant count if available, otherwise raw count of Participant objects.
+        // This is to accommodate events with no explicit participants entered (e.g. only a category).
+        $parStat = $this->getStatistic('participants');
+        return null !== $parStat ? (int)$parStat->getValue() : $this->participants->count();
     }
 
     /**


### PR DESCRIPTION
Since #173 we are storing Participants as a stat, so the views
automatically show it. This removes the old code that manually showed
the participant count, except for the Participants form where it should
continue to show the count of participants entered.

Bug: T206692
Bug: T216523