### PR TITLE
Store event-level pages with uploaded files and expose it in report

### DIFF
--- a/app/Resources/views/events/event_summary.wikitext.twig
+++ b/app/Resources/views/events/event_summary.wikitext.twig
@@ -4,7 +4,7 @@
 &bull; [https://meta.wikimedia.org/wiki/Event_Metrics/Definitions_of_metrics {{ msg('metrics-about-link') }}]</small>
 
 {| class="wikitable"{#-
--#}{% for metric in ['participants', 'pages-created', 'pages-improved', 'byte-difference', 'files-uploaded', 'items-created', 'items-improved', 'pages-created-pageviews', 'pages-improved-pageviews-avg'] %}
+-#}{% for metric in ['participants', 'pages-created', 'pages-improved', 'byte-difference', 'files-uploaded', 'items-created', 'items-improved', 'pages-created-pageviews', 'pages-improved-pageviews-avg', 'pages-using-files'] %}
 {% set stat = event.getStatistic(metric) %}
 {% if stat is not empty %}
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -114,6 +114,7 @@
 	"pages-improved": "Pages improved",
 	"pages-improved-desc": "A content page is a page in either the main or file namespace.",
 	"pages-improved-pageviews-avg": "Avg. daily views to pages improved",
+	"pages-using-files": "Unique pages with uploaded files",
 	"participants": "Participants",
 	"please-login": "Please login to continue.",
 	"program": "Program",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -113,6 +113,7 @@
 	"pages-improved": "Heading for the column listing the number of pages improved during a program, shown in the 'My Programs' table.",
 	"pages-improved-desc": "Description for the 'pages improved' metric.",
 	"pages-improved-pageviews-avg": "Label for the metric that indicates the average daily pageviews there were to the pages improved during an event.",
+	"pages-using-files": "Label for the metric indicating how many unique content pages use the files that were uploaded during the event.",
 	"participants": "Heading for the column listing the number of participants of a program in the 'My Programs' table.",
 	"please-login": "Error message saying the user needs to login in order to continue.",
 	"program": "Heading for the column listing program titles in the 'My Programs' table.\n{{Identical|Program}}",

--- a/src/AppBundle/Service/EventProcessor.php
+++ b/src/AppBundle/Service/EventProcessor.php
@@ -319,6 +319,7 @@ class EventProcessor
             $this->createOrUpdateEventStat('byte-difference', $this->byteDifference);
             $this->createOrUpdateEventStat('files-uploaded', $this->filesUploaded);
             $this->createOrUpdateEventStat('file-usage', $this->fileUsage);
+            $this->createOrUpdateEventStat('pages-using-files', $this->pagesUsingFiles);
         }
 
         $this->log(">> <info>Edits: {$this->edits}</info>");

--- a/tests/AppBundle/Command/ProcessEventCommandTest.php
+++ b/tests/AppBundle/Command/ProcessEventCommandTest.php
@@ -153,7 +153,7 @@ class ProcessEventCommandTest extends EventMetricsTestCase
         $eventStats = $this->entityManager
             ->getRepository('Model:EventStat')
             ->findAll(['event' => $this->event]);
-        static::assertEquals(13, count($eventStats));
+        static::assertEquals(14, count($eventStats));
     }
 
     /**

--- a/tests/AppBundle/Controller/EventDataControllerTest.php
+++ b/tests/AppBundle/Controller/EventDataControllerTest.php
@@ -182,7 +182,7 @@ class EventDataControllerTest extends DatabaseAwareWebTestCase
         $eventStats = $this->entityManager
             ->getRepository('Model:EventStat')
             ->findBy(['event' => $event]);
-        static::assertEquals(13, count($eventStats));
+        static::assertEquals(14, count($eventStats));
     }
 
     /**


### PR DESCRIPTION
The Event Summary report cares about total unique pages with the files
uploaded, for the whole event. This commit stores that (EventStat rather
than just EventWikiStat), and exposes it in the Event Summary wikitext
report so that it can be QA'd.

Bug: T215356