### PR TITLE
Skip stats that don't exist on Event Summary page

### DIFF
--- a/app/Resources/views/events/show.html.twig
+++ b/app/Resources/views/events/show.html.twig
@@ -34,15 +34,17 @@
                     <table class="event-metadata event-metadata--grouped">
                         {% for metric in event.visibleMetrics if metric in commonMetrics %}
                             {% set stat = event.statistic(metric) %}
-                            <tr>
-                                <th scope="row">
-                                    {{ msg(metric, [stat.offset]) }}:
-                                    {% if msg_exists(stat.metric ~ '-desc', [stat.offset]) %}
-                                        <span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="top" title="{{ msg(stat.metric ~ '-desc', [stat.offset]) }}"></span>
-                                    {% endif %}
-                                </th>
-                                <td>{{ stat.value|num_format }}</td>
-                            </tr>
+                            {% if stat is not null %}
+                                <tr>
+                                    <th scope="row">
+                                        {{ msg(metric, [stat.offset]) }}:
+                                        {% if msg_exists(stat.metric ~ '-desc', [stat.offset]) %}
+                                            <span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="top" title="{{ msg(stat.metric ~ '-desc', [stat.offset]) }}"></span>
+                                        {% endif %}
+                                    </th>
+                                    <td>{{ stat.value|num_format }}</td>
+                                </tr>
+                            {% endif %}
                         {% endfor %}
                     </table>
 

--- a/tests/AppBundle/Controller/EventDataControllerTest.php
+++ b/tests/AppBundle/Controller/EventDataControllerTest.php
@@ -307,9 +307,6 @@ class EventDataControllerTest extends DatabaseAwareWebTestCase
 | en.wikipedia
 | {{FORMATNUM:12}}
 | +{{FORMATNUM:4641}}
-| {{FORMATNUM:19695}}
-| {{FORMATNUM:25}}
-| {{FORMATNUM:218}}
 EOD;
         static::assertcontains($snippet, $this->response->getContent());
     }


### PR DESCRIPTION
Fix test for pages-created; pageviews cumulative of course changes