### PR TITLE
Sort Pages Created report by avg views; no redirects for incoming links

### DIFF
--- a/app/Resources/views/events/pages_created.wikitext.twig
+++ b/app/Resources/views/events/pages_created.wikitext.twig
@@ -14,19 +14,17 @@
 ! {{ msg('pageviews-average') }}
 ! {{ msg('incoming-links') }}
 ! {{ msg('more-page-metrics') }}
-{% for wiki in event.wikis %}
-{% for pageTitle, data in ewRepo.pagesCreatedData(wiki, usernames) %}
+{% for page in pagesCreated %}
 |-
-| [https://{{ wiki.domain }}.org/wiki/{{ pageTitle }} {{ pageTitle|replace({'_': ' '}) }}]
-| [https://{{ wiki.domain }}.org/wiki/User:{{ data.creator|replace({' ': '_'}) }} {{ data.creator }}]
-| {{ wiki.domain }}
-| {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ data.edits }}}}
-| +{% verbatim %}{{FORMATNUM:{% endverbatim %}{{ data.bytes }}}}
-| {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ data.pageviews }}}}
-| {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ data.avgPageviews }}}}
-| {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ data.links }}}}
-| [https://xtools.wmflabs.org/articleinfo/{{ wiki.domain }}/{{ pageTitle }} XTools]
+| [https://{{ page.wiki }}.org/wiki/{{ page.pageTitle }} {{ page.pageTitle|replace({'_': ' '}) }}]
+| [https://{{ page.wiki }}.org/wiki/User:{{ page.creator|replace({' ': '_'}) }} {{ page.creator }}]
+| {{ page.wiki }}
+| {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ page.edits }}}}
+| +{% verbatim %}{{FORMATNUM:{% endverbatim %}{{ page.bytes }}}}
+| {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ page.pageviews }}}}
+| {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ page.avgPageviews }}}}
+| {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ page.links }}}}
+| [https://xtools.wmflabs.org/articleinfo/{{ page.wiki }}/{{ page.pageTitle }} XTools]
 |-
-{% endfor %}
 {% endfor %}
 |}

--- a/src/AppBundle/Controller/EventDataController.php
+++ b/src/AppBundle/Controller/EventDataController.php
@@ -9,7 +9,6 @@ namespace AppBundle\Controller;
 
 use AppBundle\Model\Job;
 use AppBundle\Repository\EventRepository;
-use AppBundle\Repository\EventWikiRepository;
 use AppBundle\Service\JobHandler;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -90,23 +89,22 @@ class EventDataController extends EntityController
     /**
      * Pages Created report.
      * @Route("/programs/{programId}/events/{eventId}/pages-created", name="EventPagesCreated")
-     * @param EventWikiRepository $ewRepo
+     * @param EventRepository $eventRepo
      * @return Response
      */
-    public function pagesCreatedReportAction(EventWikiRepository $ewRepo): Response
+    public function pagesCreatedReportAction(EventRepository $eventRepo): Response
     {
         $format = 'csv' === $this->request->query->get('format') ? 'csv' : 'wikitext';
 
         $userIds = $this->event->getParticipantIds();
         $usernames = array_column(
-            $ewRepo->getUsernamesFromIds($userIds),
+            $eventRepo->getUsernamesFromIds($userIds),
             'user_name'
         );
 
         return $this->getFormattedResponse($format, 'pages_created', [
             'event' => $this->event,
-            'ewRepo' => $ewRepo,
-            'usernames' => $usernames,
+            'pagesCreated' => $eventRepo->getPagesCreatedData($this->event, $usernames),
         ]);
     }
 

--- a/src/AppBundle/Repository/EventRepository.php
+++ b/src/AppBundle/Repository/EventRepository.php
@@ -505,4 +505,33 @@ class EventRepository extends Repository
         $ret = $this->executeQueryBuilder($rqb, -1)->fetch();
         return isset($ret['job_started']) ? (bool)$ret['job_started'] : null;
     }
+
+    /**
+     * Get the data needed for the Pages Created report.
+     * @param Event $event
+     * @param string[] $usernames
+     * @return mixed[]
+     */
+    public function getPagesCreatedData(Event $event, array $usernames): array
+    {
+        $data = [];
+
+        /** @var EventWikiRepository $ewRepo */
+        $ewRepo = $this->em->getRepository('Model:EventWiki');
+        $ewRepo->setContainer($this->container);
+
+        foreach ($event->getWikis()->getIterator() as $wiki) {
+            $data = array_merge($data, $ewRepo->getPagesCreatedData($wiki, $usernames));
+        }
+
+        // Sort by avg. pageviews.
+        usort($data, function ($a, $b) {
+            if ($a['avgPageviews'] == $b['avgPageviews']) {
+                return 0;
+            }
+            return $a['avgPageviews'] < $b['avgPageviews'] ? 1 : -1;
+        });
+
+        return $data;
+    }
 }


### PR DESCRIPTION
Sort by average pageviews. This requires a reworking of the data
structure passed to the view.

Don't include redirects when getting a count of incoming links.

Bug: T205502