### PR TITLE
Add 'Avg. daily views to pages that have uploaded files' metric

### DIFF
--- a/app/Resources/views/events/event_summary.wikitext.twig
+++ b/app/Resources/views/events/event_summary.wikitext.twig
@@ -4,7 +4,7 @@
 &bull; [https://meta.wikimedia.org/wiki/Event_Metrics/Definitions_of_metrics {{ msg('metrics-about-link') }}]</small>
 
 {| class="wikitable"{#-
--#}{% for metric in ['participants', 'pages-created', 'pages-improved', 'byte-difference', 'files-uploaded', 'items-created', 'items-improved', 'pages-created-pageviews', 'pages-improved-pageviews-avg', 'pages-using-files'] %}
+-#}{% for metric in ['participants', 'pages-created', 'pages-improved', 'byte-difference', 'files-uploaded', 'items-created', 'items-improved', 'pages-created-pageviews', 'pages-improved-pageviews-avg', 'pages-using-files', 'pages-using-files-pageviews-avg'] %}
 {% set stat = event.getStatistic(metric) %}
 {% if stat is not empty %}
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -120,6 +120,7 @@
 	"pages-improved-desc": "A content page is a page in either the main or file namespace.",
 	"pages-improved-pageviews-avg": "Avg. daily views to pages improved",
 	"pages-using-files": "Unique pages with uploaded files",
+	"pages-using-files-pageviews-avg": "Avg. daily views to files uploaded",
 	"pageviews-average": "Avg. daily pageviews",
 	"pageviews-cumulative": "Pageviews, cumulative",
 	"participants": "Participants",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -119,6 +119,7 @@
 	"pages-improved-desc": "Description for the 'pages improved' metric.",
 	"pages-improved-pageviews-avg": "Label for the metric that indicates the average daily pageviews there were to the pages improved during an event.",
 	"pages-using-files": "Label for the metric indicating how many unique content pages use the files that were uploaded during the event.",
+	"pages-using-files-pageviews-avg": "Label for the metric indicating the average pageviews to content pages that use the files that were uploading during the event.",
 	"pageviews-average": "Label for value that is the average number of pageviews a page has received per day.",
 	"pageviews-cumulative": "Label for value that is the number of pageviews a page has received to date.",
 	"participants": "Heading for the column listing the number of participants of a program in the 'My Programs' table.",

--- a/src/AppBundle/Model/Event.php
+++ b/src/AppBundle/Model/Event.php
@@ -55,6 +55,7 @@ class Event
         'files-uploaded' => null,
         'file-usage' => null,
         'pages-using-files' => null,
+        'pages-using-files-pageviews-avg' => 30,
         'items-created' => null,
         'items-improved' => null,
     ];
@@ -73,8 +74,14 @@ class Event
             'files-uploaded',
             'file-usage',
             'pages-using-files',
+            'pages-using-files-pageviews-avg',
         ],
-        'commons' => ['files-uploaded', 'file-usage', 'pages-using-files'],
+        'commons' => [
+            'files-uploaded',
+            'file-usage',
+            'pages-using-files',
+            'pages-using-files-pageviews-avg',
+        ],
         'wikidata' => ['items-created', 'items-improved'],
     ];
 

--- a/src/AppBundle/Model/EventStat.php
+++ b/src/AppBundle/Model/EventStat.php
@@ -41,6 +41,7 @@ class EventStat
         'participants',
         'new-editors',
         'retention',
+        'pages-using-files-pageviews-avg',
 
         // These are also stored on a per-wiki basis as a EventWikiStat
         'edits',

--- a/src/AppBundle/Repository/EventRepository.php
+++ b/src/AppBundle/Repository/EventRepository.php
@@ -186,25 +186,25 @@ class EventRepository extends Repository
     }
 
     /**
-     * Get the number of unique mainspace pages across all projects that are using files
+     * Get the mainspace pages across all projects that are using files
      * uploaded by the given users that were uploaded during the given time frame.
      * @param string $dbName Database name such as 'enwiki_p'. For 'commonswiki_p' this will be global usage.
      * @param DateTime $start
      * @param DateTime $end
      * @param string[] $usernames
-     * @return int
+     * @return mixed[][] Array containing arrays with keys 'dbName' and 'pageId'].
      */
-    public function getPagesUsingFiles(string $dbName, DateTime $start, DateTime $end, array $usernames): int
+    public function getPagesUsingFiles(string $dbName, DateTime $start, DateTime $end, array $usernames): array
     {
         $rqb = $this->getFileUsageBuilder($dbName, $start, $end, $usernames);
 
         if ('commonswiki_p' === $dbName) {
-            $rqb->select('COUNT(DISTINCT(CONCAT(gil_wiki, gil_page)))');
+            $rqb->select(["CONCAT(gil_wiki, '_p') AS dbName", 'gil_page AS pageId']);
         } else {
-            $rqb->select('COUNT(DISTINCT(il_from))');
+            $rqb->select(["'$dbName' AS dbName", 'il_from AS pageId']);
         }
 
-        return (int)$this->executeQueryBuilder($rqb)->fetchColumn();
+        return $this->executeQueryBuilder($rqb)->fetchAll();
     }
 
     /**

--- a/tests/AppBundle/Command/ProcessEventCommandTest.php
+++ b/tests/AppBundle/Command/ProcessEventCommandTest.php
@@ -153,7 +153,7 @@ class ProcessEventCommandTest extends EventMetricsTestCase
         $eventStats = $this->entityManager
             ->getRepository('Model:EventStat')
             ->findAll(['event' => $this->event]);
-        static::assertEquals(14, count($eventStats));
+        static::assertEquals(15, count($eventStats));
     }
 
     /**
@@ -382,6 +382,14 @@ class ProcessEventCommandTest extends EventMetricsTestCase
                 'metric' => 'pages-created-pageviews',
             ]);
         static::assertGreaterThan(18932, $eventStat->getValue());
+
+        $eventStat = $this->entityManager
+            ->getRepository('Model:EventStat')
+            ->findOneBy([
+                'event' => $this->event,
+                'metric' => 'pages-using-files-pageviews-avg',
+            ]);
+        static::assertGreaterThan(0, $eventStat->getValue());
     }
 
     /**

--- a/tests/AppBundle/Controller/EventDataControllerTest.php
+++ b/tests/AppBundle/Controller/EventDataControllerTest.php
@@ -182,7 +182,7 @@ class EventDataControllerTest extends DatabaseAwareWebTestCase
         $eventStats = $this->entityManager
             ->getRepository('Model:EventStat')
             ->findBy(['event' => $event]);
-        static::assertEquals(14, count($eventStats));
+        static::assertEquals(15, count($eventStats));
     }
 
     /**

--- a/tests/AppBundle/Model/EventTest.php
+++ b/tests/AppBundle/Model/EventTest.php
@@ -368,6 +368,7 @@ class EventTest extends EventMetricsTestCase
                 'files-uploaded' => null,
                 'file-usage' => null,
                 'pages-using-files' => null,
+                'pages-using-files-pageviews-avg' => 30,
             ],
             $event->getAvailableMetrics()
         );


### PR DESCRIPTION
Required some reworking of how the 'Unique pages with uploaded files'
was implemented.

Bug: T206700