### PR TITLE
Remove + from byte difference in the CSV report

### DIFF
--- a/app/Resources/views/events/event_summary.csv.twig
+++ b/app/Resources/views/events/event_summary.csv.twig
@@ -2,7 +2,7 @@
     #}{% set stat = event.getStatistic(metric) %}{#
     #}{% if stat is not empty %}{#
         #}{{ msg(metric, [stat.offset]) }},{#
-        #}{% if stat.value is null %} {% else %}{% if metric == 'byte-difference' and stat.value > 0 %}+{% endif %}{{ stat.value }}{% endif %}
+        #}{% if stat.value is null %} {% else %}{{ stat.value }}{% endif %}
 
 {% endif %}{#
 #}{% endfor %}


### PR DESCRIPTION
As discussed with Joe, this is preventing spreadsheets from understanding
the number.