### PR TITLE
Use age of article when calculating average pageviews

### DIFF
--- a/src/AppBundle/Repository/EventWikiRepository.php
+++ b/src/AppBundle/Repository/EventWikiRepository.php
@@ -318,8 +318,8 @@ class EventWikiRepository extends Repository
      * @param string $pageTitle
      * @param DateTime $start
      * @param DateTime $end
-     * @param bool $includeAverage Whether to also return the average over the past N days
-     *   (as specified by Event::AVAILABLE_METRICS['pages-improved-pageviews-avg'], safe to say they should be in sync).
+     * @param bool $includeAverage Whether to also return the average over the past N days. This figure is the minimum
+     *   of Event::AVAILABLE_METRICS['pages-improved-pageviews-avg'] and the number of days of available data.
      * @return int|int[]|null Sum of pageviews, or [sum of pageviews, average],
      *   or null if no data was found (could be new article, 404, etc.).
      */
@@ -345,11 +345,13 @@ class EventWikiRepository extends Repository
 
         $pageviews = 0;
         $recentPageviews = 0;
-        $recentDayCount = Event::AVAILABLE_METRICS['pages-improved-pageviews-avg'];
+        $recentDayLimit = Event::AVAILABLE_METRICS['pages-improved-pageviews-avg'];
+        $recentDayCount = 0;
 
         foreach (array_reverse($pageviewsInfo['items']) as $index => $item) {
-            if ($index < $recentDayCount) {
+            if ($index < $recentDayLimit) {
                 $recentPageviews += $item['views'];
+                $recentDayCount++;
             }
             $pageviews += $item['views'];
         }

--- a/tests/AppBundle/Repository/EventWikiRepositoryTest.php
+++ b/tests/AppBundle/Repository/EventWikiRepositoryTest.php
@@ -5,23 +5,37 @@ declare(strict_types=1);
 namespace Tests\AppBundle\Repository;
 
 use AppBundle\Repository\EventWikiRepository;
+use AppBundle\Repository\PageviewsRepository;
 use DateTime;
 use Tests\AppBundle\EventMetricsTestCase;
 
+/**
+ * Tests for EventWikiRepository.
+ */
 class EventWikiRepositoryTest extends EventMetricsTestCase
 {
+    /** @var EventWikiRepository $repo */
+    private $repo;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $kernel = static::bootKernel();
+
+        /** @var \Doctrine\ORM\EntityManager $entityManager */
+        $entityManager = $kernel->getContainer()->get('doctrine')->getManager();
+
+        $this->repo = new EventWikiRepository($entityManager);
+        $this->repo->setContainer($kernel->getContainer());
+    }
 
     /**
      * @covers \AppBundle\Repository\EventWikiRepository::getPageIds()
      */
     public function testGetPageIds():void
     {
-        $kernel = static::bootKernel();
-        /** @var \Doctrine\ORM\EntityManager $entityManager */
-        $entityManager = $kernel->getContainer()->get('doctrine')->getManager();
-        $repo = new EventWikiRepository($entityManager);
-        $repo->setContainer($kernel->getContainer());
-        $dbName = $repo->getDbNameFromDomain('en.wikipedia');
+        $dbName = $this->repo->getDbNameFromDomain('en.wikipedia');
         $from = new DateTime('2003-11-16 13:15');
         $to = new DateTime('2003-11-16 15:19');
         $users = ['Someone else'];
@@ -29,13 +43,45 @@ class EventWikiRepositoryTest extends EventMetricsTestCase
         $pagesCreatedExpected = [         368673];
         $pagesEditedExpected  = [2112961        ];
         // All pages.
-        $allPagesActual = $repo->getPageIds($dbName, $from, $to, $users, []);
+        $allPagesActual = $this->repo->getPageIds($dbName, $from, $to, $users, []);
         static::assertEquals($allPagesExpected, $allPagesActual);
         // Pages created.
-        $pagesCreatedActual = $repo->getPageIds($dbName, $from, $to, $users, [], 'created');
+        $pagesCreatedActual = $this->repo->getPageIds($dbName, $from, $to, $users, [], 'created');
         static::assertEquals($pagesCreatedExpected, $pagesCreatedActual);
         // Pages edited.
-        $pagesEditedActual = $repo->getPageIds($dbName, $from, $to, $users, [], 'edited');
+        $pagesEditedActual = $this->repo->getPageIds($dbName, $from, $to, $users, [], 'edited');
         static::assertEquals($pagesEditedExpected, $pagesEditedActual);
+    }
+
+    /**
+     * @covers \AppBundle\Repository\EventWikiRepository::getPageviews()
+     */
+    public function testPageviews(): void
+    {
+        $pvRepo = new PageviewsRepository();
+
+        $start = new DateTime('2018-06-06');
+        $end = new DateTime('2018-06-12');
+
+        // Raw total pageviews.
+        static::assertEquals(
+            361,
+            $this->repo->getPageviewsPerArticle($pvRepo, 'en.wikipedia', 'Domino_Park', $start, $end)
+        );
+
+        [$total, $avg] = $this->repo->getPageviewsPerArticle(
+            $pvRepo,
+            'en.wikipedia',
+            'Domino_Park',
+            $start,
+            $end,
+            true
+        );
+
+        // First element should be the same as total pageviews.
+        static::assertEquals(361, $total);
+
+        // Average during the period, which should only apply to the days the article existed (June 10 - June 12).
+        static::assertEquals(120, $avg);
     }
 }


### PR DESCRIPTION
That is, the age or the 'offset' (currently 30 days), whatever is shorter.

Depends on: #206

Bug: T206700