### PR TITLE
[WIP] Fix various bugs with pageviews; some refactoring

### DIFF
--- a/tests/AppBundle/Repository/EventWikiRepositoryTest.php
+++ b/tests/AppBundle/Repository/EventWikiRepositoryTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\AppBundle\Repository;
 
 use AppBundle\Repository\EventWikiRepository;
-use AppBundle\Repository\PageviewsRepository;
 use DateTime;
 use Tests\AppBundle\EventMetricsTestCase;
 
@@ -51,37 +50,5 @@ class EventWikiRepositoryTest extends EventMetricsTestCase
         // Pages edited.
         $pagesEditedActual = $this->repo->getPageIds($dbName, $from, $to, $users, [], 'edited');
         static::assertEquals($pagesEditedExpected, $pagesEditedActual);
-    }
-
-    /**
-     * @covers \AppBundle\Repository\EventWikiRepository::getPageviews()
-     */
-    public function testPageviews(): void
-    {
-        $pvRepo = new PageviewsRepository();
-
-        $start = new DateTime('2018-06-06');
-        $end = new DateTime('2018-06-12');
-
-        // Raw total pageviews.
-        static::assertEquals(
-            361,
-            $this->repo->getPageviewsPerArticle($pvRepo, 'en.wikipedia', 'Domino_Park', $start, $end)
-        );
-
-        [$total, $avg] = $this->repo->getPageviewsPerArticle(
-            $pvRepo,
-            'en.wikipedia',
-            'Domino_Park',
-            $start,
-            $end,
-            true
-        );
-
-        // First element should be the same as total pageviews.
-        static::assertEquals(361, $total);
-
-        // Average during the period, which should only apply to the days the article existed (June 10 - June 12).
-        static::assertEquals(120, $avg);
     }
 }

--- a/tests/AppBundle/Repository/PageviewsRepositoryTest.php
+++ b/tests/AppBundle/Repository/PageviewsRepositoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\AppBundle\Repository;
 
 use AppBundle\Repository\PageviewsRepository;
+use DateTime;
 use Tests\AppBundle\EventMetricsTestCase;
 
 class PageviewsRepositoryTest extends EventMetricsTestCase
@@ -31,6 +32,7 @@ class PageviewsRepositoryTest extends EventMetricsTestCase
             new \DateTime('2019-01-01'),
             new \DateTime('2019-01-02')
         );
+
         static::assertEquals(['items' => [[
             'project' => 'zh.wikipedia',
             'article' => '一期一會',
@@ -48,5 +50,46 @@ class PageviewsRepositoryTest extends EventMetricsTestCase
             'agent' => 'user',
             'views' => 255,
         ]]], $pageviews);
+    }
+
+    /**
+     * @covers \AppBundle\Repository\PageviewsRepository::getPageviewsPerArticle()
+     */
+    public function testPageviews(): void
+    {
+        $start = new DateTime('2018-06-06');
+        $end = new DateTime('2018-06-12');
+
+        // Raw total pageviews.
+        static::assertEquals(
+            361,
+            $this->repo->getPageviewsPerArticle('en.wikipedia', 'Domino_Park', $start, $end)
+        );
+
+        [$total, $avg] = $this->repo->getPageviewsPerArticle(
+            'en.wikipedia',
+            'Domino_Park',
+            $start,
+            $end,
+            30
+        );
+
+        // First element should be the same as total pageviews.
+        static::assertEquals(361, $total);
+
+        // Average during the period, which should only apply to the days the article existed (June 10 - June 12).
+        static::assertEquals(120, $avg);
+
+        $start = new DateTime('2019-02-01');
+        $end = new DateTime('2019-02-15');
+
+        // This particular endpoint has gaps in the time series.
+        // getPageviewsPerArticle() should fill these in with zeros and give you the correct average.
+        // @see https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/wikidata/all-access/user/Q61506256/daily/20190201/20190215
+        // @see https://wikitech.wikimedia.org/wiki/Analytics/AQS/Pageviews#Gotchas
+        static::assertEquals(
+            [12, 1], // 12 total pageviews, divided by 15 days = round(0.8) = 1 average pageview a day.
+            $this->repo->getPageviewsPerArticle('www.wikidata', 'Q61506256', $start, $end, 30)
+        );
     }
 }


### PR DESCRIPTION
Account for gaps in timeseries when computing avg pageviews.

Ensure average pageviews is in relation to how long the article existed.

Refactor some pageviews logic to PageviewsRepository. In an ideal world
where we follow best practices, PageviewsRepository wouldn't have any
logic beyond fetching the data itself. But, we're breaking the same rule
in EventWikiRepository (and the others), so this refactoring at least
moves all the core pageviews logic into the same file.

Bug: T217704