### PR TITLE
Right-align numeric data in wikitext reports

### DIFF
--- a/app/Resources/views/events/event_summary.wikitext.twig
+++ b/app/Resources/views/events/event_summary.wikitext.twig
@@ -9,8 +9,14 @@
 
 |-
 | {{ msg(metric, [stat.offset]) }}
-| {% if stat.value is null %}&ndash;{% else %}{% if metric == 'byte-difference' and stat.value > 0 %}+{% endif %}{{ stat.value|num_format }}{% endif %}
-{% endif %}
+| style="text-align:right" | {% spaceless %}
+    {% if stat.value is null %}
+        &ndash;
+    {% else %}
+        {% if metric == 'byte-difference' and stat.value > 0 %}+{% endif %}{#
+        #}{{ stat.value|num_format }}
+    {% endif %}
+{% endspaceless %}{% endif %}
 {% endfor %}
 
 |}

--- a/app/Resources/views/events/pages_created.wikitext.twig
+++ b/app/Resources/views/events/pages_created.wikitext.twig
@@ -19,11 +19,11 @@
 | {{ wikiHelper.pageLink(page.pageTitle, page.wiki, null, true) }}
 | {{ wikiHelper.pageLink('User:' ~ page.creator, page.wiki, page.creator, true) }}
 | {{ page.wiki }}
-| {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ page.edits }}}}
-| +{% verbatim %}{{FORMATNUM:{% endverbatim %}{{ page.bytes }}}}
-| {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ page.pageviews }}}}
-| {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ page.avgPageviews }}}}
-| {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ page.links }}}}
+| style="text-align:right" | {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ page.edits }}}}
+| style="text-align:right" | +{% verbatim %}{{FORMATNUM:{% endverbatim %}{{ page.bytes }}}}
+| style="text-align:right" | {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ page.pageviews }}}}
+| style="text-align:right" | {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ page.avgPageviews }}}}
+| style="text-align:right" | {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ page.links }}}}
 | [https://xtools.wmflabs.org/articleinfo/{{ page.wiki }}/{{ page.pageTitle }} XTools]
 |-
 {% endfor %}

--- a/tests/AppBundle/Controller/EventDataControllerTest.php
+++ b/tests/AppBundle/Controller/EventDataControllerTest.php
@@ -202,6 +202,7 @@ class EventDataControllerTest extends DatabaseAwareWebTestCase
 
         foreach ($states as $constant => $value) {
             // No idea why we have to fetch the Event on every iteration; something clashing with PHPUnit and Doctrine.
+            /** @var Event $event */
             $event = $this->entityManager
                 ->getRepository('Model:Event')
                 ->findOneBy(['title' => 'Oliver_and_Company']);
@@ -274,7 +275,10 @@ class EventDataControllerTest extends DatabaseAwareWebTestCase
         $this->response = $this->client->getResponse();
 
         // Basic assertion to ensure data is being outputed.
-        static::assertContains("Pages created\n| 3", $this->response->getContent());
+        static::assertContains(
+            "Pages created\n| style=\"text-align:right\" | 3",
+            $this->response->getContent()
+        );
     }
 
     /**
@@ -305,8 +309,8 @@ class EventDataControllerTest extends DatabaseAwareWebTestCase
 | [https://en.wikipedia.org/wiki/Domino_Park Domino Park]
 | [https://en.wikipedia.org/wiki/User:MusikAnimal MusikAnimal]
 | en.wikipedia
-| {{FORMATNUM:12}}
-| +{{FORMATNUM:4636}}
+| style="text-align:right" | {{FORMATNUM:12}}
+| style="text-align:right" | +{{FORMATNUM:4636}}
 EOD;
         static::assertcontains($snippet, $this->response->getContent());
     }


### PR DESCRIPTION
Some cleanup to event summary wikitext template to make it more
readable.

Bug: T205502