### PR TITLE
URL-encode page titles in Twig templates, and use raw in CSV export

### DIFF
--- a/app/Resources/views/events/pages_created.csv.twig
+++ b/app/Resources/views/events/pages_created.csv.twig
@@ -1,6 +1,6 @@
 "{{ msg('title') }}","{{ msg('url') }}","{{ msg('creator') }}","{{ msg('wiki') }}","{{ msg('edits-during-event') }}","{{ msg('byte-difference-during-event') }}","{{ msg('pageviews-cumulative') }}","{{ msg('pageviews-average') }}","{{ msg('incoming-links') }}","{{ msg('more-page-metrics') }}"
 {% for page in pagesCreated %}
-"{{ page.pageTitle|replace({'_': ' '}) }}","https://{{ page.wiki }}.org/wiki/{{ page.pageTitle }}","{{ page.creator }}",{{ page.wiki }},{{ page.edits }},{{ page.bytes }},{{ page.pageviews }},{{ page.avgPageviews }},{{ page.links }},"https://xtools.wmflabs.org/articleinfo/{{ page.wiki }}/{{ page.pageTitle }}"
+"{{ page.pageTitle|replace({'_': ' '})|raw }}","https://{{ page.wiki }}.org/wiki/{{ page.pageTitle|e('url') }}","{{ page.creator }}",{{ page.wiki }},{{ page.edits }},{{ page.bytes }},{{ page.pageviews }},{{ page.avgPageviews }},{{ page.links }},"https://xtools.wmflabs.org/articleinfo/{{ page.wiki }}/{{ page.pageTitle|e('url') }}"
 {% endfor %}
 
 {{ msg('pages-created') }},{{ event.displayTitle }}

--- a/app/Resources/views/events/pages_created.wikitext.twig
+++ b/app/Resources/views/events/pages_created.wikitext.twig
@@ -24,7 +24,7 @@
 | style="text-align:right" | {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ page.pageviews }}}}
 | style="text-align:right" | {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ page.avgPageviews }}}}
 | style="text-align:right" | {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ page.links }}}}
-| [https://xtools.wmflabs.org/articleinfo/{{ page.wiki }}/{{ page.pageTitle }} XTools]
+| [https://xtools.wmflabs.org/articleinfo/{{ page.wiki }}/{{ page.pageTitle|e('url') }} XTools]
 |-
 {% endfor %}
 |}

--- a/app/Resources/views/macros/wiki.html.twig
+++ b/app/Resources/views/macros/wiki.html.twig
@@ -12,9 +12,9 @@
         {% if label is empty %}
             {% set label = pageTitle %}
         {% endif %}
-        [{{ 'https://' ~ domain ~ '.org/wiki/' ~ pageTitle|replace({' ': '_'}) }} {{ label|replace({'_': ' '}) }}]
+        [{{ 'https://' ~ domain ~ '.org/wiki/' ~ pageTitle|replace({' ': '_'})|e('url') }} {{ label|replace({'_': ' '}) }}]
     {% else %}
-        {{ extLink('https://' ~ domain ~ '.org/wiki/' ~ pageTitle, pageTitle|replace({'_': ' '}), label) }}
+        {{ extLink('https://' ~ domain ~ '.org/wiki/' ~ pageTitle|e('url'), pageTitle|replace({'_': ' '}), label) }}
     {% endif %}
 {% endspaceless %}{% endmacro %}
 
@@ -27,5 +27,5 @@
     {% if rev is not iterable %}
         {% set rev = {page: rev, namespace: ns} %}
     {% endif %}
-    {{ (rev.namespace == 6 ? 'File:' : '') ~ rev.page }}
+    {{ ((rev.namespace == 6 ? 'File:' : '') ~ rev.page|replace({' ': '_'}))|raw }}
 {% endspaceless %}{% endmacro %}

--- a/tests/AppBundle/Controller/EventDataControllerTest.php
+++ b/tests/AppBundle/Controller/EventDataControllerTest.php
@@ -111,6 +111,7 @@ class EventDataControllerTest extends DatabaseAwareWebTestCase
      */
     public function testCategory(): void
     {
+        /** @var Event $event */
         $event = $this->entityManager
             ->getRepository('Model:Event')
             ->findOneBy(['title' => 'Oliver_and_Company']);
@@ -137,13 +138,13 @@ class EventDataControllerTest extends DatabaseAwareWebTestCase
         // 12 are to [[Domino Park]].
         static::assertEquals(
             12,
-            substr_count($this->response->getContent(), 'https://en.wikipedia.org/wiki/Domino Park')
+            substr_count($this->response->getContent(), 'https://en.wikipedia.org/wiki/Domino_Park')
         );
 
         // 3 are files.
         static::assertEquals(
             3,
-            substr_count($this->response->getContent(), '/wiki/File:')
+            substr_count($this->response->getContent(), '/wiki/File%3A')
         );
     }
 
@@ -307,7 +308,7 @@ class EventDataControllerTest extends DatabaseAwareWebTestCase
 
         $snippet = <<<EOD
 | [https://en.wikipedia.org/wiki/Domino_Park Domino Park]
-| [https://en.wikipedia.org/wiki/User:MusikAnimal MusikAnimal]
+| [https://en.wikipedia.org/wiki/User%3AMusikAnimal MusikAnimal]
 | en.wikipedia
 | style="text-align:right" | {{FORMATNUM:12}}
 | style="text-align:right" | +{{FORMATNUM:4636}}


### PR DESCRIPTION
Bug: T215923