### PR TITLE
Add support for categories without participants

### DIFF
--- a/app/Resources/views/events/show.html.twig
+++ b/app/Resources/views/events/show.html.twig
@@ -42,7 +42,13 @@
                                             <span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="top" title="{{ msg(stat.metric ~ '-desc', [stat.offset]) }}"></span>
                                         {% endif %}
                                     </th>
-                                    <td>{{ stat.value|num_format }}</td>
+                                    <td>
+                                        {% if stat.value is null %}
+                                            &ndash;
+                                        {% else %}
+                                            {{ stat.value|num_format }}
+                                        {% endif %}
+                                    </td>
                                 </tr>
                             {% endif %}
                         {% endfor %}
@@ -61,9 +67,8 @@
                 <div class="text-center event-wiki-stats--empty">
                     {% if event.hasJob %}
                         &nbsp;
-                    {% elseif event.numParticipants == 0 %}
-                        {# FIXME: ^ also check for event.numCategories == 0 and add msg('categories') once T194707#4620358 is resolved #}
-                        {{ msg('event-misconfig', [msg('participants')]) }}
+                    {% elseif event.numParticipants == 0 and event.numCategories == 0 %}
+                        {{ msg('event-misconfig', [[msg('participants'), msg('categories')]|join(', ')]) }}
                     {% elseif event.startUTC > date() %}
                         {{ msg('event-in-future') }}
                         (<a href="{{ path('EditEvent', {'programId': program.id, 'eventId': event.id}) }}">{{ msg('settings')|lower }}</a>)

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -9,12 +9,9 @@ namespace AppBundle\Controller;
 
 use AppBundle\Model\Event;
 use AppBundle\Model\EventCategory;
-use AppBundle\Model\EventStat;
 use AppBundle\Model\EventWiki;
 use AppBundle\Model\Participant;
 use AppBundle\Service\JobHandler;
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -204,39 +201,9 @@ class EventController extends EntityController
             'forms' => $forms,
             'program' => $this->program,
             'event' => $this->event,
-            'stats' => $this->getEventStats($this->event),
             'isOrganizer' => $this->authUserIsOrganizer($this->program),
             'job' => $this->event->getJob(),
         ]);
-    }
-
-    /**
-     * Get EventStats from the given Event. If there are none, empty EventStats are returned for each metric type
-     * specified by EventStat::METRIC_TYPES, with the default 'offset' values specified by Event::getAvailableMetrics().
-     * This way we can show placeholders in the view.
-     * @param Event $event
-     * @return Collection|EventStat[]
-     */
-    private function getEventStats(Event $event): Collection
-    {
-        if (count($event->getStatistics()) > 0) {
-            return $event->getStatistics();
-        }
-
-        $availableMetrics = $event->getAvailableMetrics();
-        $stats = new ArrayCollection();
-
-        foreach (EventStat::getMetricTypes() as $metric) {
-            if (!in_array($metric, array_keys($availableMetrics))) {
-                continue;
-            }
-
-            $stats->add(
-                new EventStat($event, $metric, null, $availableMetrics[$metric])
-            );
-        }
-
-        return $stats;
     }
 
     /****************

--- a/src/AppBundle/DataFixtures/ORM/extended.yml
+++ b/src/AppBundle/DataFixtures/ORM/extended.yml
@@ -26,8 +26,10 @@ AppBundle\Model\EventWiki:
         __construct: ['@event1', 'commons.wikimedia']
     eventWiki3:
         __construct: ['@event1', 'www.wikidata']
-    event2wiki:
+    event2wiki1:
         __construct: ['@event2', 'en.wikipedia']
+    event2wiki2:
+        __construct: ['@event2', 'commons.wikimedia']
 AppBundle\Model\Participant:
     MusikAnimal:
         # See https://en.wikipedia.org/wiki/Special:Contribs/MusikAnimal?namespace=0&start=2018-06-10&end=2018-06-11
@@ -52,3 +54,6 @@ AppBundle\Model\Participant:
 AppBundle\Model\EventCategory:
     eventCategory1:
         __construct: ['@event2', 'Parks in Brooklyn', 'en.wikipedia']
+    eventCategory2:
+        # One file upload in period: https://commons.wikimedia.org/wiki/File:DSC00988_YAKIMA,_WASHINGTON_FROM_THE_EAST_AT_3000_FEET_OVERHEAD.jpg
+        __construct: ['@event2', 'Aerial photographs', 'commons.wikimedia']

--- a/src/AppBundle/Model/Event.php
+++ b/src/AppBundle/Model/Event.php
@@ -277,9 +277,8 @@ class Event
             null !== $this->end &&
             $this->getStartUTC() < new DateTime() &&
             (
-                $this->participants->count() > 0
-                // FIXME: uncomment once issues at T194707#4620358 are resolved.
-                // $this->categories->count() > 0
+                $this->participants->count() > 0 ||
+                $this->categories->count() > 0
             );
     }
 

--- a/src/AppBundle/Model/EventStat.php
+++ b/src/AppBundle/Model/EventStat.php
@@ -99,10 +99,10 @@ class EventStat
      * EventStat constructor.
      * @param Event $event Event the statistic applies to.
      * @param string $metric Name of event metric, e.g. 'retention', 'pages-created', 'pages-improved'.
-     * @param mixed $value Value of the associated metric.
-     * @param int $offset Offset value associated with the metric, such as number of days retention.
+     * @param int $value Value of the associated metric.
+     * @param int|null $offset Offset value associated with the metric, such as number of days retention.
      */
-    public function __construct(Event $event, string $metric, $value, $offset = null)
+    public function __construct(Event $event, string $metric, int $value = 0, ?int $offset = null)
     {
         $this->event = $event;
         $this->event->addStatistic($this);

--- a/src/AppBundle/Model/Traits/EventStatTrait.php
+++ b/src/AppBundle/Model/Traits/EventStatTrait.php
@@ -80,6 +80,7 @@ trait EventStatTrait
         $this->stats->clear();
         $this->setUpdated(null);
 
+        /** @var EventWiki $wiki */
         foreach ($this->wikis->getIterator() as $wiki) {
             $wiki->clearStatistics();
         }

--- a/src/AppBundle/Service/EventProcessor.php
+++ b/src/AppBundle/Service/EventProcessor.php
@@ -220,7 +220,7 @@ class EventProcessor
         $count = count($usernames);
         $this->createOrUpdateEventStat('participants', $count);
         $this->logEnd($logKey);
-        $this->log(">> <info>Participants: $count</info>");
+        $this->log("> <info>Participants: $count</info>");
     }
 
     /**
@@ -234,7 +234,7 @@ class EventProcessor
         $newEditorOffset = Event::getAllAvailableMetrics()['new-editors'];
         $this->createOrUpdateEventStat('new-editors', $numNewEditors, $newEditorOffset);
         $this->logEnd($logKey);
-        $this->log(">> <info>New editors: $numNewEditors</info>");
+        $this->log("> <info>New editors: $numNewEditors</info>");
     }
 
     /**
@@ -455,6 +455,12 @@ class EventProcessor
         $logKey = 'files_uploaded_'.$wiki->getDomain();
         $this->logStart("> Fetching files uploaded on {$wiki->getDomain()} and global file usage...", $logKey);
 
+        if (false === $wiki->canHaveFilesUploaded()) {
+            $this->logEnd($logKey);
+            $this->log(">> <comment>File metrics not applicable, skipping</comment>");
+            return;
+        }
+
         $dbName = $ewRepo->getDbNameFromDomain($wiki->getDomain());
         $start = $this->event->getStartUTC();
         $end = $this->event->getEndUTC();
@@ -532,7 +538,7 @@ class EventProcessor
         $usernames = $this->getParticipantNames();
         if ($pageIds && !$usernames && $this->event->getNumCategories() > 0) {
             $usernames = $ewRepo->getUsersFromPageIDs($dbName, $pageIds, $this->event);
-            $this->implicitEditors += array_flip($usernames);
+            $this->implicitEditors = array_merge($this->implicitEditors, $usernames);
         }
 
         $this->logEnd($logKey);
@@ -781,7 +787,7 @@ class EventProcessor
     {
         $this->stopwatch->stop($key);
         $message = $message ?? 'Done';
-        $duration = round($this->stopwatch->getEvent($key)->getDuration(), 2);
+        $duration = round($this->stopwatch->getEvent($key)->getDuration());
         $this->log(" <comment>$message ($duration ms)</comment>");
     }
 }

--- a/tests/AppBundle/Command/ProcessEventCommandTest.php
+++ b/tests/AppBundle/Command/ProcessEventCommandTest.php
@@ -435,6 +435,9 @@ class ProcessEventCommandTest extends EventMetricsTestCase
         static::assertEquals(1, $eventStat->getValue());
     }
 
+    /**
+     * Event with a category and no participants.
+     */
     public function testEventsWithoutParticipants(): void
     {
         $this->prepareEvent(['title' => 'Event_without_participants']);
@@ -446,9 +449,9 @@ class ProcessEventCommandTest extends EventMetricsTestCase
             ->getRepository('Model:EventStat')
             ->findOneBy([
                 'event' => $this->event,
-                'metric' => 'retention',
+                'metric' => 'participants',
             ]);
-        static::assertEquals(0, $eventStat->getValue());
+        static::assertEquals(6, $eventStat->getValue());
 
         $eventStat = $this->entityManager
             ->getRepository('Model:EventStat')
@@ -456,6 +459,22 @@ class ProcessEventCommandTest extends EventMetricsTestCase
                 'event' => $this->event,
                 'metric' => 'new-editors',
             ]);
-        static::assertEquals(0, $eventStat->getValue());
+        static::assertEquals(1, $eventStat->getValue());
+
+        $eventStat = $this->entityManager
+            ->getRepository('Model:EventStat')
+            ->findOneBy([
+                'event' => $this->event,
+                'metric' => 'pages-improved',
+            ]);
+        static::assertEquals(2, $eventStat->getValue());
+
+        $eventStat = $this->entityManager
+            ->getRepository('Model:EventStat')
+            ->findOneBy([
+                'event' => $this->event,
+                'metric' => 'files-uploaded',
+            ]);
+        static::assertEquals(3, $eventStat->getValue());
     }
 }

--- a/tests/AppBundle/Controller/EventDataControllerTest.php
+++ b/tests/AppBundle/Controller/EventDataControllerTest.php
@@ -156,12 +156,12 @@ class EventDataControllerTest extends DatabaseAwareWebTestCase
         );
         $this->response = $this->client->getResponse();
 
-        // Exactly 27 edits.
-        static::assertEquals(27, $this->crawler->filter('.event-revision')->count());
+        // Exactly 29 edits.
+        static::assertEquals(29, $this->crawler->filter('.event-revision')->count());
 
-        // 12 edits to enwiki.
+        // 14 edits to enwiki.
         static::assertEquals(
-            12,
+            14,
             substr_count($this->response->getContent(), '<td class="text-nowrap">en.wikipedia</td>')
         );
 
@@ -171,10 +171,16 @@ class EventDataControllerTest extends DatabaseAwareWebTestCase
             substr_count($this->response->getContent(), 'https://en.wikipedia.org/wiki/Domino_Park')
         );
 
-        // 1 file upload.
+        // 1 Commons file upload.
         static::assertEquals(
             1,
-            substr_count($this->response->getContent(), '/wiki/File%3A')
+            substr_count($this->response->getContent(), 'commons.wikimedia.org/wiki/File%3A')
+        );
+
+        // 2 local file uploads.
+        static::assertEquals(
+            2,
+            substr_count($this->response->getContent(), 'en.wikipedia.org/wiki/File%3A')
         );
     }
 
@@ -274,6 +280,7 @@ class EventDataControllerTest extends DatabaseAwareWebTestCase
     private function generateStats(Event $event): void
     {
         $this->killDbConnections();
+
         // Update the stats, creating a new Job for the Event and flushing to the database.
         $job = new Job($event);
         $this->entityManager->persist($job);
@@ -346,6 +353,6 @@ class EventDataControllerTest extends DatabaseAwareWebTestCase
 | style="text-align:right" | {{FORMATNUM:12}}
 | style="text-align:right" | +{{FORMATNUM:4636}}
 EOD;
-        static::assertcontains($snippet, $this->response->getContent());
+        static::assertContains($snippet, $this->response->getContent());
     }
 }


### PR DESCRIPTION
Add support for categories without participants

This can still fail very large categories, but we'll iron out performance
issues later. Most categories process just fine without any error.

Some metrics don't apply when there are no participants, such as local
file uploads (there could be thousands, most presumably unrelated to the
event). To address this, we introduce EventWiki::canHaveFilesUploaded()
and also EventWiki::isValid(). The latter ensures there are at least
some participants or one category to work with.

Remove unused EventController::getEventStats().

Other minor code cleanup.

Bug: T205734