### PR TITLE
Return 0 for avg pageviews if there were no recent pageviews

### DIFF
--- a/src/AppBundle/Repository/PageviewsRepository.php
+++ b/src/AppBundle/Repository/PageviewsRepository.php
@@ -97,6 +97,10 @@ class PageviewsRepository
         }
 
         if (is_int($avgDaysOffset)) {
+            if (null === $lastAvgDate) {
+                // No recent pageviews, so average is 0.
+                return [$pageviews, 0];
+            }
             $numDays = $end->diff($lastAvgDate)->days + 1; // +1 because dates are inclusive.
             return [$pageviews, (int)round($recentPageviews / $numDays)];
         }


### PR DESCRIPTION
In computing averages, we look for pageviews only in the past 31 days.
If there are none, $lastAvgDate doesn't get set and an exception is
thrown. This commit fixes this and has it simply return 0 as the
average.

Bug: T217704