### PR TITLE
End date for pageviews should always be yesterday at midnight

### DIFF
--- a/src/AppBundle/Repository/EventWikiRepository.php
+++ b/src/AppBundle/Repository/EventWikiRepository.php
@@ -539,7 +539,7 @@ class EventWikiRepository extends Repository
         $pages = $this->getPageTitles($dbName, $wiki->getPagesCreated(), true, true);
         $start = $wiki->getEvent()->getStartUTC();
         $end = $wiki->getEvent()->getEndUTC();
-        $now = new DateTime();
+        $now = new DateTime('yesterday midnight');
         $data = [];
 
         while ($page = $pages->fetch()) {


### PR DESCRIPTION
Pageviews API takes at least 24 hours to populate.

Bug: T217704