### PR TITLE
Store files uploaded as their own type of page IDs, update queries

### DIFF
--- a/app/DoctrineMigrations/Version20190314042732.php
+++ b/app/DoctrineMigrations/Version20190314042732.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20190314042732 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE event_wiki ADD ew_pages_files LONGBLOB DEFAULT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE event_wiki DROP ew_pages_files');
+    }
+}

--- a/src/AppBundle/Model/EventWiki.php
+++ b/src/AppBundle/Model/EventWiki.php
@@ -93,6 +93,14 @@ class EventWiki
     protected $pagesEdited;
 
     /**
+     * A bzcompressed string of all the IDs of the pages for files uploaded.
+     * See note above in $pagesCreated docblock about storage.
+     * @ORM\Column(name="ew_pages_files", type="blob", nullable=true)
+     * @var string|resource
+     */
+    protected $pagesFiles;
+
+    /**
      * EventWiki constructor.
      * @param Event $event Event that this EventWiki belongs to.
      * @param string $domain Domain name of the wiki, without the .org.
@@ -253,6 +261,7 @@ class EventWiki
         // It's safe to assume page IDs should also be cleared.
         $this->pagesCreated = null;
         $this->pagesEdited = null;
+        $this->pagesFiles = null;
     }
 
     /*********
@@ -303,6 +312,23 @@ class EventWiki
     }
 
     /**
+     * Get the cached/persisted page IDs of all pages for files uploaded during this event.
+     * @return int[]
+     */
+    public function getPagesFiles(): array
+    {
+        return $this->getPageIds('files');
+    }
+
+    /**
+     * @param int[]|null $ids
+     */
+    public function setPagesFiles(?array $ids): void
+    {
+        $this->setPageIds('files', $ids);
+    }
+
+    /**
      * @param string $type Which type of page IDs to return.
      * @return int[]
      * @throws Exception With invalid type.
@@ -334,7 +360,7 @@ class EventWiki
      */
     protected function setPageIds(string $type, ?array $ids):void
     {
-        if (!in_array($type, ['created', 'edited'])) {
+        if (!in_array($type, ['created', 'edited', 'files'])) {
             throw new Exception('$type must be "created" or "edited".');
         }
         $propertyName = 'pages'.ucfirst($type);

--- a/src/AppBundle/Service/EventProcessor.php
+++ b/src/AppBundle/Service/EventProcessor.php
@@ -456,15 +456,16 @@ class EventProcessor
         $start = $this->event->getStartUTC();
         $end = $this->event->getEndUTC();
 
-        $ret = $this->eventRepo->getFilesUploaded($dbName, $start, $end, $this->getParticipantNames(), $categories);
-        $this->createOrUpdateEventWikiStat($wiki, 'files-uploaded', $ret);
-        $this->filesUploaded += $ret;
+        $pageIds = $ewRepo->getPageIds($dbName, $start, $end, $this->getParticipantNames(), $categories, 'files');
+        $this->createOrUpdateEventWikiStat($wiki, 'files-uploaded', count($pageIds));
+        $wiki->setPagesFiles($pageIds);
+        $this->filesUploaded += count($pageIds);
 
-        $ret = $this->eventRepo->getUsedFiles($dbName, $start, $end, $this->getParticipantNames(), $categories);
+        $ret = $this->eventRepo->getUsedFiles($dbName, $pageIds);
         $this->createOrUpdateEventWikiStat($wiki, 'file-usage', $ret);
         $this->fileUsage += $ret;
 
-        $ret = $this->eventRepo->getPagesUsingFiles($dbName, $start, $end, $this->getParticipantNames(), $categories);
+        $ret = $this->eventRepo->getPagesUsingFiles($dbName, $pageIds);
         $this->createOrUpdateEventWikiStat($wiki, 'pages-using-files', count($ret));
         $this->pagesUsingFiles += count($ret);
         $this->pageTitlesUsingFiles = array_merge($this->pageTitlesUsingFiles, $ret);

--- a/tests/AppBundle/Repository/EventRepositoryTest.php
+++ b/tests/AppBundle/Repository/EventRepositoryTest.php
@@ -30,22 +30,4 @@ class EventRepositoryTest extends EventMetricsTestCase
         static::assertGreaterThan(0, $this->repo->getPagesUsingFile('commonswiki_p', 'Ultrasonic_humidifier.jpg'));
         static::assertGreaterThan(0, $this->repo->getPagesUsingFile('enwiki_p', '2-cube.png'));
     }
-
-    /**
-     * Ensures we only count unique pages that are using the files.
-     * For this example we use an old abandoned account with numerous files used on the same page.
-     * @see https://commons.wikimedia.org/wiki/Special:Contributions/Krupin.1
-     */
-    public function testGetPagesUsingFiles(): void
-    {
-        $ret = $this->repo->getPagesUsingFiles(
-            'commonswiki_p',
-            new \DateTime('2014-12-01'),
-            new \DateTime('2014-12-02'),
-            ['Krupin.1'],
-            []
-        );
-
-        static::assertCount(1, $ret);
-    }
 }


### PR DESCRIPTION
This simplifies the code and makes the queries faster. Additionally, the
revision table retains the original uploader of the file, while going
off of the image table we only get the most recent version (which may be
by a non-participant).

On the backend, the "type" of page ID is called "pagesFiles" -- the name
chosen so it can use the helpers for "pagesCreated" and "pagesImproved"
that reference class property by the given 'type'.

Only use revision_userindex when filtering by user.