### PR TITLE
[WIP] Allow stat values to be null, display as a ndash in the UI.

### DIFF
--- a/app/DoctrineMigrations/Version20190314070711.php
+++ b/app/DoctrineMigrations/Version20190314070711.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20190314070711 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE event_wiki_stat CHANGE ews_value ews_value INT DEFAULT 0');
+        $this->addSql('ALTER TABLE event_stat CHANGE es_value es_value INT DEFAULT 0');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE event_stat CHANGE es_value es_value INT DEFAULT 0 NOT NULL');
+        $this->addSql('ALTER TABLE event_wiki_stat CHANGE ews_value ews_value INT DEFAULT 0 NOT NULL');
+    }
+}

--- a/app/Resources/views/events/show.html.twig
+++ b/app/Resources/views/events/show.html.twig
@@ -42,7 +42,13 @@
                                             <span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="top" title="{{ msg(stat.metric ~ '-desc', [stat.offset]) }}"></span>
                                         {% endif %}
                                     </th>
-                                    <td>{{ stat.value|num_format }}</td>
+                                    <td>
+                                        {% if stat.value is null %}
+                                            &ndash;
+                                        {% else %}
+                                            {{ stat.value|num_format }}
+                                        {% endif %}
+                                    </td>
                                 </tr>
                             {% endif %}
                         {% endfor %}

--- a/src/AppBundle/Model/EventStat.php
+++ b/src/AppBundle/Model/EventStat.php
@@ -90,8 +90,8 @@ class EventStat
     protected $offset;
 
     /**
-     * @ORM\Column(name="es_value", type="integer", options={"default":0})
-     * @var int Value of the associated metric.
+     * @ORM\Column(name="es_value", type="integer", options={"default":0}, nullable=true)
+     * @var int|null Value of the associated metric.
      */
     protected $value;
 
@@ -99,10 +99,10 @@ class EventStat
      * EventStat constructor.
      * @param Event $event Event the statistic applies to.
      * @param string $metric Name of event metric, e.g. 'retention', 'pages-created', 'pages-improved'.
-     * @param mixed $value Value of the associated metric.
-     * @param int $offset Offset value associated with the metric, such as number of days retention.
+     * @param int|null $value Value of the associated metric.
+     * @param int|null $offset Offset value associated with the metric, such as number of days retention.
      */
-    public function __construct(Event $event, string $metric, $value, $offset = null)
+    public function __construct(Event $event, string $metric, ?int $value = null, ?int $offset = null)
     {
         $this->event = $event;
         $this->event->addStatistic($this);

--- a/src/AppBundle/Model/EventWikiStat.php
+++ b/src/AppBundle/Model/EventWikiStat.php
@@ -86,8 +86,8 @@ class EventWikiStat
     protected $offset;
 
     /**
-     * @ORM\Column(name="ews_value", type="integer", options={"default":0})
-     * @var int Value of the associated metric.
+     * @ORM\Column(name="ews_value", type="integer", options={"default":0}, nullable=true)
+     * @var int|null Value of the associated metric.
      */
     protected $value;
 


### PR DESCRIPTION
Some metrics we report 0 when it's really a N/A. With this commit
these metrics can be saved as null. This allows us to replace the
confusing 0's in the UI to a simple &ndash;