### PR TITLE
Kill active database connections between tests

### DIFF
--- a/src/AppBundle/Service/JobHandler.php
+++ b/src/AppBundle/Service/JobHandler.php
@@ -102,17 +102,16 @@ class JobHandler
      * @param Job $job
      * @param OutputInterface &$output Used by Commands so that the output can be controlled by the parent process.
      *   If this is null, a local LoggerInterface is used instead.
+     * @throws \Exception
      */
     public function spawn(Job $job, ?OutputInterface &$output = null): void
     {
         $this->output = $output;
 
-        /**
-         * We can't stub the number of open connections, without stubbing all database interaction with a Repository.
-         * @codeCoverageIgnoreStart
-         */
+        // We can't stub the number of open connections, without stubbing all database interaction with a Repository.
+        // @codeCoverageIgnoreStart
         if (0 === $this->getQuota()) {
-            return;
+            throw new \Exception('Database quota exceeded!');
         }
         // @codeCoverageIgnoreEnd
 

--- a/tests/AppBundle/Controller/EventDataControllerTest.php
+++ b/tests/AppBundle/Controller/EventDataControllerTest.php
@@ -37,6 +37,7 @@ class EventDataControllerTest extends DatabaseAwareWebTestCase
      */
     public function testRevisions(): void
     {
+        /** @var Event $event */
         $event = $this->entityManager
             ->getRepository('Model:Event')
             ->findOneBy(['title' => 'Oliver_and_Company']);


### PR DESCRIPTION
Apparently they persist, which can cause you to hit the 5-connection
limit imposed on the replicas. This issue is intermittent.

Also throw Exception in JobHandler when db connection limit is hit,
so that it's more clear what went wrong.