### PR TITLE
Rm static caching in EventProcessor; fix timestamps when fetching users

### DIFF
--- a/src/AppBundle/Repository/EventWikiRepository.php
+++ b/src/AppBundle/Repository/EventWikiRepository.php
@@ -445,8 +445,8 @@ class EventWikiRepository extends Repository
             ->andWhere('rev_user <> 0')
             ->andWhere('rev_timestamp BETWEEN :start AND :end')
             ->setParameter('pageIds', $pageIds, Connection::PARAM_INT_ARRAY)
-            ->setParameter('start', $event->getStart()->format('YmdHis'))
-            ->setParameter('end', $event->getEnd()->format('YmdHis'));
+            ->setParameter('start', $event->getStartUTC()->format('YmdHis'))
+            ->setParameter('end', $event->getEndUTC()->format('YmdHis'));
 
         return $this->executeQueryBuilder($rqb)->fetchAll(\PDO::FETCH_COLUMN);
     }

--- a/src/AppBundle/Service/EventProcessor.php
+++ b/src/AppBundle/Service/EventProcessor.php
@@ -79,6 +79,9 @@ class EventProcessor
     /** @var Stopwatch used to profile performance. */
     private $stopwatch;
 
+    /** @var string[] Usernames of Participants. */
+    private $participantNames;
+
     /**
      * Constructor for the EventProcessor.
      * @param LoggerInterface $logger
@@ -541,18 +544,17 @@ class EventProcessor
      */
     private function getParticipantNames(): array
     {
-        // Quick cache.
-        static $parUsernames = null;
-        if (null !== $parUsernames) {
-            return $parUsernames;
+        if (isset($this->participantNames)) {
+            return $this->participantNames;
         }
 
         $userIds = $this->event->getParticipantIds();
-        $parUsernames = array_column(
+        $this->participantNames = array_column(
             $this->eventRepo->getUsernamesFromIds($userIds),
             'user_name'
         );
-        return $parUsernames;
+
+        return $this->participantNames;
     }
 
     /**

--- a/tests/AppBundle/Command/ProcessEventCommandTest.php
+++ b/tests/AppBundle/Command/ProcessEventCommandTest.php
@@ -448,7 +448,7 @@ class ProcessEventCommandTest extends EventMetricsTestCase
                 'event' => $this->event,
                 'metric' => 'retention',
             ]);
-        static::assertEquals(1, $eventStat->getValue());
+        static::assertEquals(0, $eventStat->getValue());
 
         $eventStat = $this->entityManager
             ->getRepository('Model:EventStat')
@@ -456,6 +456,6 @@ class ProcessEventCommandTest extends EventMetricsTestCase
                 'event' => $this->event,
                 'metric' => 'new-editors',
             ]);
-        static::assertEquals(1, $eventStat->getValue());
+        static::assertEquals(0, $eventStat->getValue());
     }
 }


### PR DESCRIPTION
This commit is a subset of #217

Remove "quick cache" crap in EventProcessor. This was caching things
between requests (or at least between integration tests), causing
erroneous results. Instead we'll use a class property to cache the
usernames.

ix timestamps in EventWikiRepository::getUsersFromPageIDs(). They should
be in UTC.

Bug: T205734