### PR TITLE
Exclude pages created from pages improved and rename the entity property

### DIFF
--- a/app/DoctrineMigrations/Version20190322001628.php
+++ b/app/DoctrineMigrations/Version20190322001628.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20190322001628 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE event_wiki CHANGE ew_pages_edited ew_pages_improved LONGBLOB DEFAULT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE event_wiki CHANGE ew_pages_improved ew_pages_edited BLOB DEFAULT NULL');
+    }
+}

--- a/src/AppBundle/Model/EventWiki.php
+++ b/src/AppBundle/Model/EventWiki.php
@@ -87,10 +87,10 @@ class EventWiki
 
     /**
      * A bzcompressed string of all the IDs of pages improved. See note above in $pagesCreated docblock about storage.
-     * @ORM\Column(name="ew_pages_edited", type="blob", nullable=true)
+     * @ORM\Column(name="ew_pages_improved", type="blob", nullable=true)
      * @var string|resource
      */
-    protected $pagesEdited;
+    protected $pagesImproved;
 
     /**
      * A bzcompressed string of all the IDs of the pages for files uploaded.
@@ -288,7 +288,7 @@ class EventWiki
 
         // It's safe to assume page IDs should also be cleared.
         $this->pagesCreated = null;
-        $this->pagesEdited = null;
+        $this->pagesImproved = null;
         $this->pagesFiles = null;
     }
 
@@ -302,7 +302,7 @@ class EventWiki
      */
     public function getPages(): array
     {
-        return array_unique(array_merge($this->getPagesCreated(), $this->getPagesEdited(), $this->getPagesFiles()));
+        return array_unique(array_merge($this->getPagesCreated(), $this->getPagesImproved(), $this->getPagesFiles()));
     }
 
     /**
@@ -323,20 +323,20 @@ class EventWiki
     }
 
     /**
-     * Get the cached/persisted page IDs of all pages edited during this event (they may also have been created).
+     * Get the cached/persisted page IDs of all pages improved during this event (does not include pages created).
      * @return int[]
      */
-    public function getPagesEdited(): array
+    public function getPagesImproved(): array
     {
-        return $this->getPageIds('edited');
+        return $this->getPageIds('improved');
     }
 
     /**
      * @param int[]|null $ids
      */
-    public function setPagesEdited(?array $ids): void
+    public function setPagesImproved(?array $ids): void
     {
-        $this->setPageIds('edited', $ids);
+        $this->setPageIds('improved', $ids);
     }
 
     /**
@@ -363,8 +363,8 @@ class EventWiki
      */
     protected function getPageIds(string $type): array
     {
-        if (!in_array($type, ['created', 'edited', 'files'])) {
-            throw new Exception('$type must be "created", "edited" or "files".');
+        if (!in_array($type, ['created', 'improved', 'files'])) {
+            throw new Exception('$type must be "created", "improved" or "files".');
         }
         $propertyName = 'pages'.ucfirst($type);
         if (null === $this->$propertyName) {
@@ -382,14 +382,14 @@ class EventWiki
     /**
      * Set the $this->pages property from the IDs, as bzcompressed and base64-encoded string.
      * @see https://secure.php.net/manual/en/function.bzcompress.php
-     * @param string $type Which type of page IDs to store: 'created' or 'edited'.
+     * @param string $type Which type of page IDs to store: 'created', 'improved' or 'files'.
      * @param int[]|null $ids
      * @throws Exception With invalid type.
      */
     protected function setPageIds(string $type, ?array $ids):void
     {
-        if (!in_array($type, ['created', 'edited', 'files'])) {
-            throw new Exception('$type must be "created", "edited" or "files".');
+        if (!in_array($type, ['created', 'improved', 'files'])) {
+            throw new Exception('$type must be "created", "improved" or "files".');
         }
         $propertyName = 'pages'.ucfirst($type);
         if (null === $ids) {

--- a/src/AppBundle/Repository/EventWikiRepository.php
+++ b/src/AppBundle/Repository/EventWikiRepository.php
@@ -208,6 +208,7 @@ class EventWikiRepository extends Repository
      * @param string[] $usernames
      * @param string[] $categoryTitles
      * @param string $type Whether only pages 'created' or 'edited' should be returned. Default is to return both.
+     *   To get pages improved, first get edited then use array_diff against created.
      * @return int[]
      */
     public function getPageIds(

--- a/src/AppBundle/Service/EventProcessor.php
+++ b/src/AppBundle/Service/EventProcessor.php
@@ -55,7 +55,7 @@ class EventProcessor
     /** @var int Number of edits made during the event. */
     private $edits = 0;
 
-    /** @var int Number of pages edited during the event. */
+    /** @var int Number of pages improved during the event (excluding page creations). */
     private $pagesImproved = 0;
 
     /** @var int Number of pages created. */
@@ -183,7 +183,7 @@ class EventProcessor
     }
 
     /**
-     * After we've created the EventWikiStats from $this->setPagesEdited(), we want to remove any with zero values
+     * After we've created the EventWikiStats from $this->setPagesImproved(), we want to remove any with zero values
      * that are associated to a family EventWiki. This is because on the event page, we don't want to show zero values
      * for *every* language that is part of a wiki family.
      */
@@ -280,7 +280,7 @@ class EventProcessor
                 $dbName,
                 $wiki->getDomain(),
                 $start,
-                $wiki->getPagesEdited(),
+                $wiki->getPagesImproved(),
                 true
             );
 
@@ -299,7 +299,7 @@ class EventProcessor
         $this->createOrUpdateEventStat('pages-improved-pageviews-avg', $avgPageviewsImprovedTotal);
         $this->createOrUpdateEventStat('pages-using-files-pageviews-avg', $avgPageviewsPagesUsingFiles);
         $this->log(">> <info>Pageviews of pages created: $pageviewsCreatedTotal</info>");
-        $this->log(">> <info>Average daily pageviews of pages edited: $avgPageviewsImprovedTotal</info>");
+        $this->log(">> <info>Average daily pageviews of pages improved: $avgPageviewsImprovedTotal</info>");
         $this->log(">> <info>Average daily pageviews to pages using files: $avgPageviewsPagesUsingFiles</info>");
     }
 
@@ -409,18 +409,13 @@ class EventProcessor
         $start = $this->event->getStartUTC();
         $end = $this->event->getEndUTC();
         $usernames = $this->getParticipantNames();
-        $categoryTitles = $this->event->getCategoryTitlesForWiki($wiki);
 
         $logKey = 'page_ids'.$wiki->getDomain();
         $this->logStart(">> Fetching page IDs...", $logKey);
-        $pageIdsCreated = $ewRepo->getPageIds($dbName, $start, $end, $usernames, $categoryTitles, 'created');
-        $pageIdsEdited = $ewRepo->getPageIds($dbName, $start, $end, $usernames, $categoryTitles, 'edited');
 
-        // Set on the EventWiki, so this will get persisted to the database.
-        $wiki->setPagesCreated($pageIdsCreated);
-        $wiki->setPagesEdited($pageIdsEdited);
+        [$pageIdsCreated, $pageIdsImproved] = $this->getAndSetPageIds($wiki, $ewRepo, $dbName);
 
-        $pageIds = array_merge($pageIdsCreated, $pageIdsEdited);
+        $pageIds = array_merge($pageIdsCreated, $pageIdsImproved);
         $totalEditCount = $this->eventRepo->getTotalEditCount($dbName, $pageIds, $start, $end, $usernames);
 
         $this->logEnd($logKey);
@@ -432,15 +427,15 @@ class EventProcessor
         $this->log(">>> <info>Bytes changed: {$diff}</info>");
 
         $totalCreated = count($pageIdsCreated);
-        $totalEdited = count($pageIdsEdited);
+        $totalImproved = count($pageIdsImproved);
         $this->pagesCreated += $totalCreated;
-        $this->pagesImproved += $totalEdited;
+        $this->pagesImproved += $totalImproved;
         $this->edits += $totalEditCount;
         $this->byteDifference += $diff;
 
         $this->createOrUpdateEventWikiStat($wiki, 'edits', $totalEditCount);
         $this->createOrUpdateEventWikiStat($wiki, 'pages-created', $totalCreated);
-        $this->createOrUpdateEventWikiStat($wiki, 'pages-improved', $totalEdited);
+        $this->createOrUpdateEventWikiStat($wiki, 'pages-improved', $totalImproved);
         $this->createOrUpdateEventWikiStat($wiki, 'byte-difference', $diff);
     }
 
@@ -496,29 +491,43 @@ class EventProcessor
         $logKey = 'wikidata_items';
         $this->logStart("> Fetching items created or improved on Wikidata...", $logKey);
 
-        $dbName = 'wikidatawiki_p';
+        [$pageIdsCreated, $pageIdsImproved] = $this->getAndSetPageIds($wiki, $ewRepo, 'wikidatawiki_p');
+
+        $this->logEnd($logKey);
+
+        // Report the counts, and record them both for this wiki and the event (there's only ever one Wikidata wiki).
+        $totalCreated = count($pageIdsCreated);
+        $totalImproved = count($pageIdsImproved);
+        $this->log(">> <info>Items created: $totalCreated</info>");
+        $this->log(">> <info>Items improved: $totalImproved</info>");
+        $this->createOrUpdateEventWikiStat($wiki, 'items-created', $totalCreated);
+        $this->createOrUpdateEventWikiStat($wiki, 'items-improved', $totalImproved);
+        $this->createOrUpdateEventStat('items-created', $totalCreated);
+        $this->createOrUpdateEventStat('items-improved', $totalImproved);
+    }
+
+    /**
+     * Set and get pages created and improved IDs on the given $wiki.
+     * @param EventWiki $wiki
+     * @param EventWikiRepository $ewRepo
+     * @param string $dbName
+     * @return int[][]
+     */
+    private function getAndSetPageIds(EventWiki &$wiki, EventWikiRepository $ewRepo, string $dbName): array
+    {
         $start = $this->event->getStartUTC();
         $end = $this->event->getEndUTC();
         $usernames = $this->getParticipantNames();
         $categoryTitles = $this->event->getCategoryTitlesForWiki($wiki);
         $pageIdsCreated = $ewRepo->getPageIds($dbName, $start, $end, $usernames, $categoryTitles, 'created');
         $pageIdsEdited = $ewRepo->getPageIds($dbName, $start, $end, $usernames, $categoryTitles, 'edited');
+        $pageIdsImproved = array_diff($pageIdsEdited, $pageIdsCreated);
 
         // Set on the EventWiki, so this will get persisted to the database.
         $wiki->setPagesCreated($pageIdsCreated);
-        $wiki->setPagesEdited($pageIdsEdited);
+        $wiki->setPagesImproved($pageIdsImproved);
 
-        $this->logEnd($logKey);
-
-        // Report the counts, and record them both for this wiki and the event (there's only ever one Wikidata wiki).
-        $totalCreated = count($pageIdsCreated);
-        $totalEdited = count($pageIdsEdited);
-        $this->log(">> <info>Items created: $totalCreated</info>");
-        $this->log(">> <info>Items improved: $totalEdited</info>");
-        $this->createOrUpdateEventWikiStat($wiki, 'items-created', $totalCreated);
-        $this->createOrUpdateEventWikiStat($wiki, 'items-improved', $totalEdited);
-        $this->createOrUpdateEventStat('items-created', $totalCreated);
-        $this->createOrUpdateEventStat('items-improved', $totalEdited);
+        return [$pageIdsCreated, $pageIdsImproved];
     }
 
     /**

--- a/tests/AppBundle/Command/ProcessEventCommandTest.php
+++ b/tests/AppBundle/Command/ProcessEventCommandTest.php
@@ -242,7 +242,7 @@ class ProcessEventCommandTest extends EventMetricsTestCase
                 'event' => $this->event,
                 'metric' => 'pages-improved',
             ]);
-        static::assertEquals(7, $eventStat->getValue());
+        static::assertEquals(6, $eventStat->getValue());
 
         $eventWikiStat = $this->entityManager
             ->getRepository('Model:EventWikiStat')
@@ -250,7 +250,7 @@ class ProcessEventCommandTest extends EventMetricsTestCase
                 'wiki' => $this->event->getWikiByDomain('en.wikipedia'),
                 'metric' => 'pages-improved',
             ]);
-        static::assertEquals(7, $eventWikiStat->getValue());
+        static::assertEquals(6, $eventWikiStat->getValue());
     }
 
     /**
@@ -347,13 +347,13 @@ class ProcessEventCommandTest extends EventMetricsTestCase
         $ewItemsCreatedStat = $eventWikiStat->findOneBy(['wiki' => $wikidata, 'metric' => 'items-created']);
         static::assertEquals(2, $ewItemsCreatedStat->getValue());
         $ewItemsImprovedStat = $eventWikiStat->findOneBy(['wiki' => $wikidata, 'metric' => 'items-improved']);
-        static::assertEquals(4, $ewItemsImprovedStat->getValue());
+        static::assertEquals(2, $ewItemsImprovedStat->getValue());
 
         // Event stats.
         $eItemsCreatedStat = $eventStat->findOneBy(['event' => $this->event, 'metric' => 'items-created']);
         static::assertEquals(2, $eItemsCreatedStat->getValue());
         $eItemsImprovedStat = $eventStat->findOneBy(['event' => $this->event, 'metric' => 'items-improved']);
-        static::assertEquals(4, $eItemsImprovedStat->getValue());
+        static::assertEquals(2, $eItemsImprovedStat->getValue());
     }
 
     /**
@@ -418,7 +418,7 @@ class ProcessEventCommandTest extends EventMetricsTestCase
         $this->persistJob();
         $this->commandTester->execute(['eventId' => $this->event->getId()]);
 
-        // Should be only 1 page created and improved, ([[Domino Park]]).
+        // Should be only 1 page created, ([[Domino Park]]).
         $eventStat = $this->entityManager
             ->getRepository('Model:EventStat')
             ->findOneBy([
@@ -426,13 +426,15 @@ class ProcessEventCommandTest extends EventMetricsTestCase
                 'metric' => 'pages-created',
             ]);
         static::assertEquals(1, $eventStat->getValue());
+
+        // We don't count edits to created pages as 'improved'.
         $eventStat = $this->entityManager
             ->getRepository('Model:EventStat')
             ->findOneBy([
                 'event' => $this->event,
                 'metric' => 'pages-improved',
             ]);
-        static::assertEquals(1, $eventStat->getValue());
+        static::assertEquals(0, $eventStat->getValue());
     }
 
     /**
@@ -467,7 +469,7 @@ class ProcessEventCommandTest extends EventMetricsTestCase
                 'event' => $this->event,
                 'metric' => 'pages-improved',
             ]);
-        static::assertEquals(2, $eventStat->getValue());
+        static::assertEquals(1, $eventStat->getValue());
 
         $eventStat = $this->entityManager
             ->getRepository('Model:EventStat')

--- a/tests/AppBundle/Model/EventWikiTest.php
+++ b/tests/AppBundle/Model/EventWikiTest.php
@@ -146,8 +146,8 @@ class EventWikiTest extends EventMetricsTestCase
         // Basic setter/getter.
         $wiki->setPagesCreated([1, 2, 3]);
         static::assertEquals([1, 2, 3], $wiki->getPagesCreated());
-        $wiki->setPagesEdited([4, 5, 6]);
-        static::assertEquals([4, 5, 6], $wiki->getPagesEdited());
+        $wiki->setPagesImproved([4, 5, 6]);
+        static::assertEquals([4, 5, 6], $wiki->getPagesImproved());
         static::assertEquals([1, 2, 3, 4, 5, 6], $wiki->getPages());
 
         // Make sure that empty strings are removed, and strings are cast to integers.

--- a/tests/AppBundle/Repository/EventWikiRepositoryTest.php
+++ b/tests/AppBundle/Repository/EventWikiRepositoryTest.php
@@ -30,25 +30,22 @@ class EventWikiRepositoryTest extends EventMetricsTestCase
     }
 
     /**
+     * Further coverage in ProcessEventCommandTest.
      * @covers \AppBundle\Repository\EventWikiRepository::getPageIds()
      */
-    public function testGetPageIds():void
+    public function testGetPageIds(): void
     {
         $dbName = $this->repo->getDbNameFromDomain('en.wikipedia');
-        $from = new DateTime('2003-11-16 13:15');
-        $to = new DateTime('2003-11-16 15:19');
-        $users = ['Someone else'];
-        $allPagesExpected     = [2112961, 368673];
-        $pagesCreatedExpected = [         368673];
-        $pagesEditedExpected  = [2112961        ];
+        $from = new DateTime('2018-06-09 04:00');
+        $to = new DateTime('2018-06-12 03:59');
+        $users = ['MusikAnimal', 'Jon Kolbert'];
+        $allPagesExpected     = [57645508, 55751986]; // [[Domino Park]], [[Spring Creek Park]]
+        $pagesCreatedExpected = [57645508          ]; // [[Domino Park]]
         // All pages.
-        $allPagesActual = $this->repo->getPageIds($dbName, $from, $to, $users, []);
+        $allPagesActual = $this->repo->getPageIds($dbName, $from, $to, $users, ['Parks_in_Brooklyn']);
         static::assertEquals($allPagesExpected, $allPagesActual);
         // Pages created.
-        $pagesCreatedActual = $this->repo->getPageIds($dbName, $from, $to, $users, [], 'created');
+        $pagesCreatedActual = $this->repo->getPageIds($dbName, $from, $to, $users, ['Parks_in_Brooklyn'], 'created');
         static::assertEquals($pagesCreatedExpected, $pagesCreatedActual);
-        // Pages edited.
-        $pagesEditedActual = $this->repo->getPageIds($dbName, $from, $to, $users, [], 'edited');
-        static::assertEquals($pagesEditedExpected, $pagesEditedActual);
     }
 }


### PR DESCRIPTION
This was semi-fixed before, but still broke if a participant edited the
page after creating it.

Writing a query that looked for unique pages edited, but not created, by
a list of users and/or within a category, turned out too be a mess and
possibly infeasible. Instead, we fetch the pages created then edited,
and subtract the arrays. This logic is handled in EventProcessor.

Other minor code refactoring.

Bug: T217455