### PR TITLE
Fix phpunit deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "wikimedia/toolforge-bundle": "^0.13"
     },
     "require-dev": {
+        "dms/phpunit-arraysubset-asserts": "^0.1.0",
         "doctrine/doctrine-fixtures-bundle": "^3.0",
         "johnkary/phpunit-speedtrap": "^3.0",
         "mediawiki/minus-x": "^0.3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4f1be5daf23c2e62334af058359cd17c",
+    "content-hash": "ec29f4ab7bd2fe2e7ba7cfaf9c2f5de9",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -3465,6 +3465,47 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "dms/phpunit-arraysubset-asserts",
+            "version": "v0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rdohms/phpunit-arraysubset-asserts.git",
+                "reference": "d618ece5d53e05be87eba835b079377eaafbd7c8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rdohms/phpunit-arraysubset-asserts/zipball/d618ece5d53e05be87eba835b079377eaafbd7c8",
+                "reference": "d618ece5d53e05be87eba835b079377eaafbd7c8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2",
+                "phpunit/phpunit": "^8.0"
+            },
+            "require-dev": {
+                "dms/coding-standard": "^1.0",
+                "squizlabs/php_codesniffer": "^3.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DMS\\PHPUnitExtensions\\ArraySubset\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rafael Dohms",
+                    "email": "rdohms@gmail.com"
+                }
+            ],
+            "description": "This package provides Array Subset and related asserts once depracated in PHPunit 8",
+            "time": "2019-02-17T14:29:58+00:00"
+        },
         {
             "name": "doctrine/data-fixtures",
             "version": "v1.3.1",

--- a/tests/AppBundle/Command/SpawnJobsCommandTest.php
+++ b/tests/AppBundle/Command/SpawnJobsCommandTest.php
@@ -126,7 +126,7 @@ class SpawnJobsCommandTest extends EventMetricsTestCase
         static::assertEquals(0, $this->commandTester->getStatusCode());
 
         $output = $this->commandTester->getDisplay();
-        static::assertContains('No jobs found in the queue', $output);
+        static::assertStringContainsString('No jobs found in the queue', $output);
     }
 
     /**
@@ -154,7 +154,7 @@ class SpawnJobsCommandTest extends EventMetricsTestCase
         $this->commandTester->execute([]);
         static::assertTrue($job->isBusy());
         $output = $this->commandTester->getDisplay();
-        static::assertContains('Event statistics successfully saved', $output);
+        static::assertStringContainsString('Event statistics successfully saved', $output);
         static::assertEquals(0, $this->commandTester->getStatusCode());
     }
 
@@ -167,13 +167,13 @@ class SpawnJobsCommandTest extends EventMetricsTestCase
         // First try bogus job ID.
         $this->commandTester->execute(['--id' => 12345]);
         $output = $this->commandTester->getDisplay();
-        static::assertContains('No job found', $output);
+        static::assertStringContainsString('No job found', $output);
         static::assertEquals(1, $this->commandTester->getStatusCode());
 
         $this->commandTester->execute(['--id' => $job->getId()]);
         static::assertTrue($job->isBusy());
         $output = $this->commandTester->getDisplay();
-        static::assertContains('Event statistics successfully saved', $output);
+        static::assertStringContainsString('Event statistics successfully saved', $output);
         static::assertEquals(0, $this->commandTester->getStatusCode());
     }
 }

--- a/tests/AppBundle/Controller/DefaultControllerTest.php
+++ b/tests/AppBundle/Controller/DefaultControllerTest.php
@@ -7,6 +7,8 @@ declare(strict_types=1);
 
 namespace Tests\AppBundle\Controller;
 
+use DMS\PHPUnitExtensions\ArraySubset\Assert;
+
 /**
  * The DefaultControllerTest tests the home page and related actions.
  */
@@ -20,7 +22,10 @@ class DefaultControllerTest extends DatabaseAwareWebTestCase
         $this->crawler = $this->client->request('GET', '/');
         $this->response = $this->client->getResponse();
         static::assertEquals(200, $this->response->getStatusCode());
-        static::assertContains('Welcome to Event Metrics', $this->crawler->filter('.splash-dialog')->text());
+        static::assertStringContainsString(
+            'Welcome to Event Metrics',
+            $this->crawler->filter('.splash-dialog')->text()
+        );
     }
 
     /**
@@ -69,7 +74,8 @@ class DefaultControllerTest extends DatabaseAwareWebTestCase
         $this->client->request('GET', '/api/wikis');
         $this->response = $this->client->getResponse();
 
-        static::assertArraySubset(
+        // @see https://github.com/sebastianbergmann/phpunit/issues/3494
+        Assert::assertArraySubset(
             [
                 'de.wikipedia' => 'dewiki_p',
                 'www.wikidata' => 'wikidatawiki_p',

--- a/tests/AppBundle/Controller/EventControllerTest.php
+++ b/tests/AppBundle/Controller/EventControllerTest.php
@@ -130,7 +130,7 @@ class EventControllerTest extends DatabaseAwareWebTestCase
         static::assertTrue($this->response->isRedirect());
 
         $this->crawler = $this->client->followRedirect();
-        static::assertContains(
+        static::assertStringContainsString(
             'Please login to continue',
             $this->crawler->filter('.splash-dialog')->text()
         );
@@ -191,7 +191,7 @@ class EventControllerTest extends DatabaseAwareWebTestCase
     {
         $this->crawler = $this->client->request('GET', $this->getProgramUrl().'/events/new');
         static::assertEquals(200, $this->client->getResponse()->getStatusCode());
-        static::assertContains(
+        static::assertStringContainsString(
             'Create a new event',
             $this->crawler->filter('.page-header')->text()
         );
@@ -242,7 +242,7 @@ class EventControllerTest extends DatabaseAwareWebTestCase
 
         $this->crawler = $this->client->followRedirect();
 
-        static::assertContains(
+        static::assertStringContainsString(
             'The Lion King',
             $this->crawler->filter('.page-subject-title')->text()
         );
@@ -251,7 +251,7 @@ class EventControllerTest extends DatabaseAwareWebTestCase
         $this->crawler = $this->client->request('GET', $this->getProgramUrl());
 
         // New event should be deletable.
-        static::assertNotContains(
+        static::assertStringNotContainsString(
             'disabled',
             $this->crawler->filter('.event-action__delete')->attr('class')
         );
@@ -362,7 +362,7 @@ class EventControllerTest extends DatabaseAwareWebTestCase
         $form['event[wikis][0]'] = 'invalid_wiki';
         $this->crawler = $this->client->submit($form);
 
-        static::assertContains(
+        static::assertStringContainsString(
             '1 wiki is invalid.',
             $this->crawler->filter('.alert-danger')->text()
         );
@@ -378,13 +378,13 @@ class EventControllerTest extends DatabaseAwareWebTestCase
         $this->response = $this->client->getResponse();
         static::assertEquals(200, $this->response->getStatusCode());
 
-        static::assertContains(
+        static::assertStringContainsString(
             'Pinocchio',
             $this->crawler->filter('.page-header')->text()
         );
 
         // Should see the 'Settings' button, since we are logged in and are one of the organizers.
-        static::assertContains(
+        static::assertStringContainsString(
             'Settings',
             $this->crawler->filter('.page-header')->text()
         );
@@ -403,7 +403,7 @@ class EventControllerTest extends DatabaseAwareWebTestCase
             "  MusikAnimal\nmusikAnimal \r\nUser_does_not_exist_1234\ninvalid|username";
         $this->crawler = $this->client->submit($form);
 
-        static::assertContains(
+        static::assertStringContainsString(
             '2 usernames are invalid',
             $this->crawler->filter('.alert-danger')->text()
         );
@@ -451,11 +451,11 @@ class EventControllerTest extends DatabaseAwareWebTestCase
         // Start with an invalid category title.
         $form['categoryForm[categories][0][title]'] = 'Invalid category 12345';
         $this->crawler = $this->client->submit($form);
-        static::assertContains(
+        static::assertStringContainsString(
             '1 category is invalid',
             $this->crawler->filter('.alert-danger')->text()
         );
-        static::assertContains(
+        static::assertStringContainsString(
             'has-error',
             $this->crawler->filter('#categoryForm_categories_0_title')->parents()->attr('class')
         );
@@ -464,7 +464,7 @@ class EventControllerTest extends DatabaseAwareWebTestCase
         $form['categoryForm[categories][0][title]'] = 'Parks in Brooklyn';
         $form['categoryForm[categories][0][domain]'] = 'invalid.wikipedia.org';
         $this->crawler = $this->client->submit($form);
-        static::assertContains(
+        static::assertStringContainsString(
             '1 category is invalid',
             $this->crawler->filter('.alert-danger')->text()
         );

--- a/tests/AppBundle/Controller/EventDataControllerTest.php
+++ b/tests/AppBundle/Controller/EventDataControllerTest.php
@@ -111,7 +111,7 @@ class EventDataControllerTest extends DatabaseAwareWebTestCase
         );
         $this->response = $this->client->getResponse();
         static::assertEquals(200, $this->response->getStatusCode());
-        static::assertContains('text/plain', $this->response->headers->get('content-type'));
+        static::assertStringContainsString('text/plain', $this->response->headers->get('content-type'));
         static::assertRegExp(
             '/en\.wikipedia.*www\.wikidata.*Samwilson.*MusikAnimal/s',
             $this->response->getContent()
@@ -129,7 +129,7 @@ class EventDataControllerTest extends DatabaseAwareWebTestCase
         );
         $this->response = $this->client->getResponse();
         static::assertEquals(200, $this->response->getStatusCode());
-        static::assertContains('text/csv', $this->response->headers->get('content-type'));
+        static::assertStringContainsString('text/csv', $this->response->headers->get('content-type'));
         static::assertRegExp(
             '/en\.wikipedia.*MusikAnimal.*wikidata\.org.*Samwilson/s',
             $this->response->getContent()
@@ -315,7 +315,7 @@ class EventDataControllerTest extends DatabaseAwareWebTestCase
         $this->response = $this->client->getResponse();
 
         // Basic assertion to ensure data is being outputed.
-        static::assertContains(
+        static::assertStringContainsString(
             "Pages created\n| style=\"text-align:right\" | 3",
             $this->response->getContent()
         );
@@ -353,7 +353,7 @@ class EventDataControllerTest extends DatabaseAwareWebTestCase
 | style="text-align:right" | {{FORMATNUM:12}}
 | style="text-align:right" | +{{FORMATNUM:4641}}
 EOD;
-        static::assertContains($snippet, $this->response->getContent());
+        static::assertStringContainsString($snippet, $this->response->getContent());
     }
 
     /**
@@ -382,6 +382,6 @@ EOD;
         $this->response = $this->client->getResponse();
 
         $snippet = '"Title","URL","Wiki","Edits during event","Bytes changed during event","Avg. daily pageviews"';
-        static::assertContains($snippet, $this->response->getContent());
+        static::assertStringContainsString($snippet, $this->response->getContent());
     }
 }

--- a/tests/AppBundle/Controller/ProgramControllerTest.php
+++ b/tests/AppBundle/Controller/ProgramControllerTest.php
@@ -41,7 +41,7 @@ class ProgramControllerTest extends DatabaseAwareWebTestCase
         $this->updateSpec();
 
         $this->crawler = $this->client->request('GET', '/programs');
-        static::assertContains(
+        static::assertStringContainsString(
             'The Lion King',
             $this->crawler->filter('.programs-list')->text()
         );
@@ -95,11 +95,11 @@ class ProgramControllerTest extends DatabaseAwareWebTestCase
         $this->crawler = $this->client->request('GET', '/programs/new');
 
         static::assertEquals(200, $this->client->getResponse()->getStatusCode());
-        static::assertContains(
+        static::assertStringContainsString(
             'Create a new program',
             $this->crawler->filter('.page-header')->text()
         );
-        static::assertContains(
+        static::assertEquals(
             'MusikAnimal',
             $this->crawler->filter('#program_organizers_0')->attr('value')
         );
@@ -151,17 +151,17 @@ class ProgramControllerTest extends DatabaseAwareWebTestCase
         $this->crawler = $this->client->request('GET', '/programs/'.$this->programId);
         $this->response = $this->client->getResponse();
         static::assertEquals(200, $this->response->getStatusCode());
-        static::assertContains(
+        static::assertStringContainsString(
             'The Lion King',
             $this->crawler->filter('.page-header')->text()
         );
-        static::assertContains(
+        static::assertStringContainsString(
             'MusikAnimal',
             $this->crawler->filter('.programs-organizers')->text()
         );
 
         // Should see the 'Settings' button, since we are logged in and are one of the organizers.
-        static::assertContains(
+        static::assertStringContainsString(
             'Settings',
             $this->crawler->filter('.page-header')->text()
         );


### PR DESCRIPTION
assertArraySubset is going to removed entirely with no alternative,
so we are now using dms/phpunit-arraysubset-asserts