### PR TITLE
Use existing EventCategory when submitting duplicate

### DIFF
--- a/src/AppBundle/Form/CategoriesType.php
+++ b/src/AppBundle/Form/CategoriesType.php
@@ -124,13 +124,26 @@ class CategoriesType extends AbstractType
     {
         return new CallbackTransformer(
             // Transform to the form.
-            function (Collection $categories) {
+            function (Collection $categories): Collection {
                 // No transformation needed.
                 return $categories;
             },
             // Transform from the form.
-            function (Collection $categories) {
+            function (Collection $categories): Collection {
+                // Loop thorugh each of the submitted categories.
                 return $categories->map(function (EventCategory $category) {
+                    // Find the existing category with the same domain and title.
+                    $oldCategory = $this->ecRepo->findOneBy([
+                        'event' => $category->getEvent(),
+                        'title' => $category->getTitle(true),
+                        'domain' => $category->getDomain(),
+                    ]);
+
+                    // Use the existing Category if found.
+                    if ($oldCategory) {
+                        return $oldCategory;
+                    }
+
                     // Fetch and set the category ID, which may be null (category does not exist).
                     $catId = $this->ecRepo->getCategoryId($category->getDomain(), $category->getTitle());
                     $category->setCategoryId($catId);


### PR DESCRIPTION
There is suerly a more proper way to do this in Symfony Forms, but this
works and mimics what we're already doing for ParticipantType.

At some point I would like to improve test coverage for the forms, where
we are adding/removing elements, but this is tedious to do and should be
saved for a separate PR.

Bug: T219732