### PR TITLE
Adjust error display for Wikidata events

### DIFF
--- a/app/Resources/views/events/_participants.html.twig
+++ b/app/Resources/views/events/_participants.html.twig
@@ -82,7 +82,7 @@
 {% set collapsed = event.updated != null %}
 {% set panelDesc = '' %}
 {# Here we use event.participants.count, ensuring it's the number of manually entered participants (and not derived). #}
-{% if event.participants.count == 0 and event.wikiByDomain('www.wikidata') %}
+{% if event.participants.count == 0 and isOnlyWikidata %}
     {% set panelDesc = msg('error-filters-wikidata-panel') ~ ' <span class="error glyphicon glyphicon-asterisk"></span>' %}
 {% elseif not filtersMissing and event.participants.count == 0 and wikisWithoutCats.count %}
     {% set panelDesc = msg('no-participants') ~ ' <span class="warn glyphicon glyphicon-warning-sign"></span>' %}

--- a/app/Resources/views/events/show.html.twig
+++ b/app/Resources/views/events/show.html.twig
@@ -50,13 +50,12 @@
                     {% endif %}
                     {% if event.wikiByDomain('www.wikidata') %}
                         <li>{{ msg('error-filters-wikidata') }}</li>
-                    {% else %}
-                        <li>{{ msg('error-filters-participants-or-categories') }}</li>
-                        <li>{{ msg('error-filters-every-wiki') }}</li>
-                        <li>{{ msg('error-filters-participants-desc') }}</li>
-                        <li>{{ msg('error-filters-categories-desc') }}</li>
-                        <li>{{ msg('error-filters-combination') }}</li>
                     {% endif %}
+                    <li>{{ msg('error-filters-participants-or-categories') }}</li>
+                    <li>{{ msg('error-filters-every-wiki') }}</li>
+                    <li>{{ msg('error-filters-participants-desc') }}</li>
+                    <li>{{ msg('error-filters-categories-desc') }}</li>
+                    <li>{{ msg('error-filters-combination') }}</li>
                 </ul>
             </section>
 


### PR DESCRIPTION
Show all bullet points unless the event is for Wikidata *only*,
and show the normal participants' form panel message.

Bug: T218340