### PR TITLE
Give full list of all unfiltered wikis

### DIFF
--- a/app/Resources/views/events/show.html.twig
+++ b/app/Resources/views/events/show.html.twig
@@ -68,14 +68,14 @@
                     {{ help_link }}
                 </p>
                 <ul>
-                    {% if wikisWithoutCats.count %}
+                    {% if wikis_without_filters.count %}
                     <li>
                         {{ msg('error-filters-categories-missing') }}
-                        {% set cats = [] %}
-                        {% for noCatWiki in wikisWithoutCats %}
-                            {% set cats = cats|merge(['<strong>' ~ noCatWiki.domain ~ '</strong>']) %}
+                        {% set unfiltered_wikis = [] %}
+                        {% for unfiltered_wiki in wikis_without_filters %}
+                            {% set unfiltered_wikis = unfiltered_wikis|merge(['<strong>' ~ unfiltered_wiki.domain ~ '</strong>']) %}
                         {% endfor %}
-                        {{ cats|list_format|raw }}
+                        {{ unfiltered_wikis|list_format|raw }}
                     </li>
                     {% endif %}
                     <li>{{ msg('error-filters-every-wiki') }}</li>

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -199,6 +199,7 @@ class EventController extends EntityController
             'isOrganizer' => $this->authUserIsOrganizer($this->program),
             'job' => $this->event->getJob(),
             'filtersMissing' => $filtersMissing,
+            'wikis_without_filters' => $this->event->getWikisWithoutFilters(),
             'wikisWithoutCats' => $this->event->getWikisWithoutCategories(),
             'isOnlyWikidata' => $isOnlyWikidata,
         ]);

--- a/src/AppBundle/Model/Event.php
+++ b/src/AppBundle/Model/Event.php
@@ -621,6 +621,22 @@ class Event
     }
 
     /**
+     * Get all of this event's wikis that do not yet have at least one category or (in the case of Wikidata) participant
+     * defined.
+     *
+     * @return Collection
+     */
+    public function getWikisWithoutFilters(): Collection
+    {
+        $wikis = $this->getWikisWithoutCategories();
+        $wikidata = $this->getWikiByDomain('www.wikidata');
+        if ($wikidata && 0 === $this->participants->count()) {
+            $wikis->add($wikidata);
+        }
+        return $wikis;
+    }
+
+    /**
      * Get all of this event's wikis that do not yet have at least one category defined.
      * Wikidata is excluded because it can never have categories.
      * @return Collection Collection of EventWiki objects.


### PR DESCRIPTION
The list of unfiltered wikis was excluding Wikidata because it
does not have categories. This adds a new method to retrieve the
uncategorized wikis and Wikidat in addition if there are no
participants.

Bug: T218340