### PR TITLE
Add linter for Twig, using the official Twig standard

### DIFF
--- a/app/Resources/views/_attribution.html.twig
+++ b/app/Resources/views/_attribution.html.twig
@@ -13,14 +13,14 @@
                 <div class="modal-body">
                     {% if exception is not defined and getControllerName() == 'default' %}
                         <p>
-                            {% set commonsLink %}
+                            {% set commons_link %}
                                 <a target="_blank" id="background_commons_link" href="#"></a>.
                             {% endset %}
-                            {{ msg('attribution-background', [commonsLink]) }}
+                            {{ msg('attribution-background', [commons_link]) }}
                         </p>
                     {% endif %}
                     <p>
-                        {% set openSans %}
+                        {% set open_sans %}
                             <a target="_blank" href="https://fonts.google.com/specimen/Open+Sans">Roboto</a>
                         {% endset %}
                         {% set apache %}
@@ -29,19 +29,19 @@
                         {% set steve %}
                             <a target="_blank" href="https://twitter.com/SteveMatteson1">Christian Robertson</a>.
                         {% endset %}
-                        {{ msg('attribution-font', [openSans, apache, steve]) }}
+                        {{ msg('attribution-font', [open_sans, apache, steve]) }}
                     </p>
                     <p>
-                        {% set fontAwesome %}
+                        {% set font_awesome %}
                             <a target="_blank" href="http://fontawesome.io/">Font Awesome</a>
                         {% endset %}
-                        {% set openFont %}
+                        {% set open_font %}
                             <a target="_blank" href="http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&amp;id=OFL">Open Font License</a>
                         {% endset %}
                         {% set dave %}
                             <a target="_blank" href="https://twitter.com/davegandy">Dave Gandy</a>.
                         {% endset %}
-                        {{ msg('attribution-font-awesome', [fontAwesome, openFont, dave]) }}
+                        {{ msg('attribution-font-awesome', [font_awesome, open_font, dave]) }}
                     </p>
                 </div>
                 <div class="modal-footer">

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -146,7 +146,7 @@
         {{ include('_footer.html.twig') }}
         {% include('_attribution.html.twig') %}
 
-        {% if 'prod' == app.environment and logged_in_user() and not(isAdmin()) %}
+        {% if 'prod' == app.environment and logged_in_user() and not (isAdmin()) %}
             {# Matomo usage tracking #}
             <script type="text/javascript">
                 var _paq = _paq || [];

--- a/app/Resources/views/blocks/forms.html.twig
+++ b/app/Resources/views/blocks/forms.html.twig
@@ -6,25 +6,25 @@
                     <span aria-hidden="true">&times;</span>
                 </button>
                 <ul class="list-unstyled">
-                    {% set errorParams = error.messageParameters %}
+                    {% set error_params = error.messageParameters %}
                     {##
                      # Merge the 'payload' variables into the messageParameters.
                      # This is how variables are passed from the models,
                      # using the message= and payload= options within the annotation.
                      #}
                     {% if error.cause.constraint.payload is defined and error.cause.constraint.payload|length > 0 %}
-                        {% set errorParams = errorParams|merge(error.cause.constraint.payload) %}
+                        {% set error_params = error_params|merge(error.cause.constraint.payload) %}
                     {% endif %}
-                    {% if error.messageTemplate == 'error-invalid' and errorParams[0] is defined %}
+                    {% if error.messageTemplate == 'error-invalid' and error_params[0] is defined %}
                         {##
                          # Special handling for generic 'error-invalid' message.
                          # Here the 0 index of the messageParameters should be the
                          # i18n message used in the <label> for the field label.
                          #}
-                        <strong>{{ msg_if_exists(errorParams[0]) }}</strong>:
+                        <strong>{{ msg_if_exists(error_params[0]) }}</strong>:
                         {{ msg_if_exists(error.messageTemplate) }}
                     {% else %}
-                        {{ msg_if_exists(error.messageTemplate, errorParams) }}
+                        {{ msg_if_exists(error.messageTemplate, error_params) }}
                     {% endif %}
                 </ul>
             </div>

--- a/app/Resources/views/events/_categories.html.twig
+++ b/app/Resources/views/events/_categories.html.twig
@@ -5,9 +5,9 @@
 
     {# If there's only one wiki configured on the Event, we want to prefill the domain and disable the input. #}
     {% if event.wikis|length == 1 and event.wikis.first.isFamilyWiki == false %}
-        {% set defaultWiki = event.wikis.first.domain %}
+        {% set default_wiki = event.wikis.first.domain %}
     {% else %}
-        {% set defaultWiki = '' %}
+        {% set default_wiki = '' %}
     {% endif %}
 
     {# This is what gets copied when they add a new category row. The index values of the names and IDs will be overriden. #}
@@ -15,7 +15,7 @@
         <div class="col-sm-2">
             <input type="text" id="categoryForm_categories_999_domain" name="categoryForm[categories][999][domain]"
                    class="wiki-input form-control" placeholder="en.wikipedia"
-                   value="{{ defaultWiki }}"{% if defaultWiki is not empty %} readonly="readonly"{% endif %}>
+                   value="{{ default_wiki }}"{% if default_wiki is not empty %} readonly="readonly"{% endif %}>
         </div>
         <div class="col-sm-4">
             <input type="text" id="categoryForm_categories_999_title" name="categoryForm[categories][999][title]"
@@ -43,11 +43,11 @@
 
     <div class="event__categories">
         {% for category in form.categories %}
-            {% set categoryRow %}
+            {% set category_row %}
                 <div class="row category-row form-group">
                     <div class="col-sm-2{{ form_errors(category.domain) ? ' has-error' }}">
                         {% set attrs = {'class': 'wiki-input', 'placeholder': 'en.wikipedia', 'autocomplete': 'off'} %}
-                        {% if defaultWiki is not empty %}
+                        {% if default_wiki is not empty %}
                             {% set attrs = attrs|merge({'readonly': 'readonly'}) %}
                         {% endif %}
                         {{ form_widget(category.domain, {'attr': attrs}) }}
@@ -63,7 +63,7 @@
                 </div>
             {% endset %}
 
-            {{ categoryRow }}
+            {{ category_row }}
         {% endfor %}
     </div>
 
@@ -83,22 +83,22 @@
 {% endset %}
 
 {% set collapsed = event.updated != null %}
-{% set panelDesc = '' %}
+{% set panel_desc = '' %}
 {% if isOnlyWikidata %}
-    {% set panelDesc = msg('wikidata-not-applicable') ~ ' <span class="glyphicon glyphicon-info-sign"></span>' %}
+    {% set panel_desc = msg('wikidata-not-applicable') ~ ' <span class="glyphicon glyphicon-info-sign"></span>' %}
     {% set collapsed = true %}
 {% elseif filtersMissing %}
-    {% set panelDesc = msg('no-categories') ~ ' <span class="error glyphicon glyphicon-asterisk"></span>' %}
+    {% set panel_desc = msg('no-categories') ~ ' <span class="error glyphicon glyphicon-asterisk"></span>' %}
 {% elseif event.participants.count == 0 and wikisWithoutCats.count %}
-    {% set panelDesc = msg('not-all-wikis-have-cats') ~ ' <span class="warn glyphicon glyphicon-warning-sign"></span>' %}
+    {% set panel_desc = msg('not-all-wikis-have-cats') ~ ' <span class="warn glyphicon glyphicon-warning-sign"></span>' %}
 {% else %}
     {% if event.numCategories(true) > 0 and form.vars.valid %}
         {# Only show participants count on valid events if there are participants. #}
-        {% set panelDesc = msg('num-categories', [event.numCategories(true)]) ~ ' <span class="success glyphicon glyphicon-ok"></span>' %}
+        {% set panel_desc = msg('num-categories', [event.numCategories(true)]) ~ ' <span class="success glyphicon glyphicon-ok"></span>' %}
     {% endif %}
     {% set collapsed = true %}
 {% endif %}
 {% if not form.vars.valid %}
     {% set collapsed = false %}
 {% endif %}
-{{ layout.panel('categories-panel-title', panelDesc, content, collapsed) }}
+{{ layout.panel('categories-panel-title', panel_desc, content, collapsed) }}

--- a/app/Resources/views/events/_form.html.twig
+++ b/app/Resources/views/events/_form.html.twig
@@ -11,8 +11,8 @@
         <div class="form-group wiki-row{{ loop.index == 1 ? ' wiki-row__template' }}">
             <div class="col-sm-2 text-right label-group">
                 {{ form_label(wiki, msg('wikis'),
-                    {'attr': {'class': form_errors(form.wikis) ? ' text-danger'}})
-                }}
+                    {'attr': {'class': form_errors(form.wikis) ? ' text-danger'}}
+                ) }}
             </div>
             <div class="col-sm-8{{ form_errors(wiki) ? ' has-error' }}">
                 {{ form_widget(wiki, {'attr': {'class': 'event-wiki-input', 'autocomplete': 'off'}}) }}

--- a/app/Resources/views/events/_header.html.twig
+++ b/app/Resources/views/events/_header.html.twig
@@ -8,20 +8,20 @@
                  # Check the job status and set messages and CSS classes accordingly.
                  #}
                 {% if event.updated == null %}
-                    {% set statsBtnText = msg('calculate-totals') %}
-                    {% set statsDesc = '' %}
+                    {% set stats_btn_text = msg('calculate-totals') %}
+                    {% set stats_desc = '' %}
                 {% else %}
-                    {% set statsBtnText = msg('update-data') %}
-                    {% set statsDesc = msg('last-updated', [event.updatedUTC|date_localize]) ~ ' (' ~ event.displayTimezone ~ ')' %}
+                    {% set stats_btn_text = msg('update-data') %}
+                    {% set stats_desc = msg('last-updated', [event.updatedUTC|date_localize]) ~ ' (' ~ event.displayTimezone ~ ')' %}
                 {% endif %}
                 {% if job != false and (job.status == constant('STATUS_STARTED', job) or job.status == constant('STATUS_QUEUED', job)) %}
-                    {% set statsBtnText = msg('updating') %}
-                    {% set statsDesc = msg('updating-desc') %}
+                    {% set stats_btn_text = msg('updating') %}
+                    {% set stats_desc = msg('updating-desc') %}
                 {% endif %}
 
                 {% if isOrganizer %}
                     <button type="button" class="btn btn-default event-process-btn" data-event-id="{{ event.id }}">
-                        <span class="event-state--initial">{{ statsBtnText }}</span>
+                        <span class="event-state--initial">{{ stats_btn_text }}</span>
                         <span class="event-state--started event-state--queued">
                             <span class="inner">
                                 {{ msg('updating') }}
@@ -32,7 +32,7 @@
                                 </span>
                             </span>
                         </span>
-                        <span class="event-state--failed-timeout event-state--failed-unknown">{{ statsBtnText }}</span>
+                        <span class="event-state--failed-timeout event-state--failed-unknown">{{ stats_btn_text }}</span>
                     </button>
                 {% endif %}
                 <div class="btn-group">
@@ -67,9 +67,9 @@
 
         {% if event.isValid %}
             <div class="event-stats-status">
-                <span class="event-state--initial">{{ statsDesc|raw }}</span>
+                <span class="event-state--initial">{{ stats_desc|raw }}</span>
                 <span class="event-state--started event-state--queued">{{ msg('updating-desc') }}</span>
-                <span class="event-state--failed-timeout event-state--failed-unknown">{{ statsDesc|raw }}</span>
+                <span class="event-state--failed-timeout event-state--failed-unknown">{{ stats_desc|raw }}</span>
             </div>
         {% endif %}
     </div>
@@ -122,8 +122,8 @@
                      # Currently we're only showing a modal for when something went wrong, and it uses the same message.
                      # If you add more state-specific messages, wrap each in their respective CSS class (e.g. event-state--queued).
                      #}
-                    {% set feedbackLink = "<a target='_blank' href='https://meta.wikimedia.org/wiki/Talk:Event_Metrics'>" ~ msg('error-event-retry-link') ~ "</a>" %}
-                    {{ msg('error-event-retry', [feedbackLink]) }}
+                    {% set feedback_link = "<a target='_blank' href='https://meta.wikimedia.org/wiki/Talk:Event_Metrics'>" ~ msg('error-event-retry-link') ~ "</a>" %}
+                    {{ msg('error-event-retry', [feedback_link]) }}
                 </p>
             </div>
         </div>

--- a/app/Resources/views/events/_metadata.html.twig
+++ b/app/Resources/views/events/_metadata.html.twig
@@ -14,25 +14,25 @@
     </tr>
     <tr>
         <th class="text-nowrap">
-            {% set wikiCount = event.orphanWikisAndFamilies|length %}
+            {% set wiki_count = event.orphanWikisAndFamilies|length %}
             {% if event.familyWikis %}
                 {# If the event includes any families (e.g. *.wikipedia) then set the count arbitrarily higher. #}
-                {% set wikiCount = 10 %}
+                {% set wiki_count = 10 %}
             {% endif %}
-            {{ msg('metadata-wikis-label', [wikiCount]) }}</th>
+            {{ msg('metadata-wikis-label', [wiki_count]) }}</th>
         <td>
-            {% set wikiLinks = [] %}
+            {% set wiki_links = [] %}
             {% for eventWiki in event.orphanWikisAndFamilies %}
                 {% if eventWiki.isFamilyWiki %}
-                    {% set wikiLink = eventWiki.domain %}
+                    {% set wiki_link = eventWiki.domain %}
                 {% else %}
-                    {% set wikiLink = '<a href="https://'~eventWiki.domain~'.org/" target="_blank">'~eventWiki.domain~'</a>' %}
+                    {% set wiki_link = '<a href="https://' ~ eventWiki.domain ~ '.org/" target="_blank">' ~ eventWiki.domain ~ '</a>' %}
                 {% endif %}
-                {% set wikiLinks = wikiLinks|merge([wikiLink]) %}
+                {% set wiki_links = wiki_links|merge([wiki_link]) %}
             {% else %}
                 {{ msg('all') }}
             {% endfor %}
-            {{ wikiLinks|list_format|raw }}
+            {{ wiki_links|list_format|raw }}
         </td>
     </tr>
 </table>

--- a/app/Resources/views/events/_participants.html.twig
+++ b/app/Resources/views/events/_participants.html.twig
@@ -5,7 +5,7 @@
         {{ form_errors(form) }}
 
         {# Valid participants should be shown below invalid ones. #}
-        {% set validParticipants = [] %}
+        {% set valid_participants = [] %}
 
         {{ form_start(form, {'method': 'post', 'attr': {'class': 'save-participants-form', 'autocomplete': 'off'}}) }}
         <p class="new-participants-label">
@@ -29,16 +29,16 @@
 
         <div class="event__participants">
             {% for participant in form.participants %}
-                {% set invalidParticipant = false %}
-                {% if not(participant.vars.valid) %}
-                    {% set invalidParticipant = true %}
+                {% set invalid_participant = false %}
+                {% if not (participant.vars.valid) %}
+                    {% set invalid_participant = true %}
                 {% endif %}
 
-                {% set participantRow %}
+                {% set participant_row %}
                     <div class="row participant-row">
-                        <div class="col-sm-4 form-group{% if invalidParticipant %} has-error{% endif %}">
+                        <div class="col-sm-4 form-group{% if invalid_participant %} has-error{% endif %}">
                             {{ form_widget(participant, {'attr': {'class': 'user-input'}}) }}
-                            {% if not(invalidParticipant) %}
+                            {% if not (invalid_participant) %}
                                 <span class="font-awesome valid-input">&#xf05d;</span>
                             {% endif %}
                         </div>
@@ -54,15 +54,15 @@
                  # If invalid, show immediately, otherwise merge into valid ones that
                  # will show below the invalid ones.
                  #}
-                {% if invalidParticipant %}
-                    {{ participantRow }}
+                {% if invalid_participant %}
+                    {{ participant_row }}
                 {% else %}
-                    {% set validParticipants = validParticipants|merge([participantRow]) %}
+                    {% set valid_participants = valid_participants|merge([participant_row]) %}
                 {% endif %}
             {% endfor %}
 
             {# Render valid participants. #}
-            {% for row in validParticipants %}
+            {% for row in valid_participants %}
                 {{ row }}
             {% endfor %}
         </div>{# .event__participants #}
@@ -80,22 +80,22 @@
 {% endset %}
 
 {% set collapsed = event.updated != null %}
-{% set panelDesc = '' %}
+{% set panel_desc = '' %}
 {# Here we use event.participants.count, ensuring it's the number of manually entered participants (and not derived). #}
 {% if event.participants.count == 0 and isOnlyWikidata %}
-    {% set panelDesc = msg('error-filters-wikidata-panel') ~ ' <span class="error glyphicon glyphicon-asterisk"></span>' %}
+    {% set panel_desc = msg('error-filters-wikidata-panel') ~ ' <span class="error glyphicon glyphicon-asterisk"></span>' %}
 {% elseif not filtersMissing and event.participants.count == 0 and wikisWithoutCats.count %}
-    {% set panelDesc = msg('no-participants') ~ ' <span class="warn glyphicon glyphicon-warning-sign"></span>' %}
+    {% set panel_desc = msg('no-participants') ~ ' <span class="warn glyphicon glyphicon-warning-sign"></span>' %}
 {% elseif filtersMissing %}
-    {% set panelDesc = msg('no-participants') ~ ' <span class="error glyphicon glyphicon-asterisk"></span>' %}
+    {% set panel_desc = msg('no-participants') ~ ' <span class="error glyphicon glyphicon-asterisk"></span>' %}
 {% else %}
     {% if event.participants.count > 0 and form.vars.valid %}
         {# Only show participants count on valid events if there are participants. #}
-        {% set panelDesc = msg('num-participants', [event.participants.count]) ~ ' <span class="success glyphicon glyphicon-ok"></span>' %}
+        {% set panel_desc = msg('num-participants', [event.participants.count]) ~ ' <span class="success glyphicon glyphicon-ok"></span>' %}
     {% endif %}
     {% set collapsed = true %}
 {% endif %}
 {% if not form.vars.valid %}
     {% set collapsed = false %}
 {% endif %}
-{{ layout.panel('participants-panel-title', panelDesc, content, collapsed) }}
+{{ layout.panel('participants-panel-title', panel_desc, content, collapsed) }}

--- a/app/Resources/views/events/revisions.html.twig
+++ b/app/Resources/views/events/revisions.html.twig
@@ -1,5 +1,4 @@
 {% extends 'base.html.twig' %}
-{% import 'macros/layout.html.twig' as layout %}
 {% import 'macros/wiki.html.twig' as wiki %}
 
 {% block breadcrumb %}
@@ -51,41 +50,41 @@
         </table>
 
         {##### PAGINATION #####}
-        {% set numPages = (numRevisions / numResultsPerPage)|round(0, 'ceil') %}
-        {% if numPages > 1 %}
-            {% set hasPrev = offset - 1 >= 1 %}
-            {% set hasNext = offset + 1 < numPages + 1 %}
-            {% set pathVars = {'programId': program.id, 'eventId': event.id} %}
+        {% set num_pages = (numRevisions / numResultsPerPage)|round(0, 'ceil') %}
+        {% if num_pages > 1 %}
+            {% set has_prev = offset - 1 >= 1 %}
+            {% set has_next = offset + 1 < num_pages + 1 %}
+            {% set path_vars = {'programId': program.id, 'eventId': event.id} %}
 
             <nav aria-label="..." class="text-center">
                 <ul class="pagination">
-                    <li{% if not(hasPrev) %} class="disabled"{% endif %}>
-                        {% if hasPrev %}
-                            <a href="{{ path('Revisions', pathVars|merge(offset == 2 ? {} : {'offset': offset - 1})) }}" aria-label="Previous">
+                    <li{% if not (has_prev) %} class="disabled"{% endif %}>
+                        {% if has_prev %}
+                            <a href="{{ path('Revisions', path_vars|merge(offset == 2 ? {} : {'offset': offset - 1})) }}" aria-label="Previous">
                         {% endif %}
                         <span aria-hidden="true">
                             <span class="glyphicon glyphicon-arrow-left"></span>
                             {{ msg('pager-older-n', [numResultsPerPage]) }}
                         </span>
-                        {% if hasPrev %}</a>{% endif %}
+                        {% if has_prev %}</a>{% endif %}
                     </li>
-                    {% for page in 1..numPages %}
+                    {% for page in 1..num_pages %}
                         {% set active = offset == loop.index %}
                         <li{% if active %} class="active"{% endif %}>
-                            <a href="{{ path('Revisions', pathVars|merge(loop.index == 1 ? {} : {'offset': loop.index})) }}">
+                            <a href="{{ path('Revisions', path_vars|merge(loop.index == 1 ? {} : {'offset': loop.index})) }}">
                                 {{ page }} {% if active %}<span class="sr-only">(current)</span>{% endif %}
                             </a>
                         </li>
                     {% endfor %}
-                    <li{% if not(hasNext) %} class="disabled"{% endif %}>
-                        {% if hasNext %}
-                            <a href="{{ path('Revisions', pathVars|merge({'offset': offset + 1})) }}" aria-label="Next">
+                    <li{% if not (has_next) %} class="disabled"{% endif %}>
+                        {% if has_next %}
+                            <a href="{{ path('Revisions', path_vars|merge({'offset': offset + 1})) }}" aria-label="Next">
                         {% endif %}
                         <span aria-hidden="true">
                             {{ msg('pager-newer-n', [numResultsPerPage]) }}
                             <span class="glyphicon glyphicon-arrow-right"></span>
                         </span>
-                        {% if hasNext %}</a>{% endif %}
+                        {% if has_next %}</a>{% endif %}
                     </li>
                 </ul>
             </nav>

--- a/app/Resources/views/events/revisions.wikitext.twig
+++ b/app/Resources/views/events/revisions.wikitext.twig
@@ -1,9 +1,9 @@
 {% import 'macros/wiki.html.twig' as wikiHelper %}
 == {{ event.displayTitle }} ==
 
-* '''{{ msg('wikis') }}''': {% set wikiListItems = [] %}
-{% for wiki in event.wikis %}{% set wikiListItems = wikiListItems|merge([wiki.domain]) %}{% endfor %}
-{{ wikiListItems|list_format }}
+* '''{{ msg('wikis') }}''': {% set wiki_list_items = [] %}
+{% for wiki in event.wikis %}{% set wiki_list_items = wiki_list_items|merge([wiki.domain]) %}{% endfor %}
+{{ wiki_list_items|list_format }}
 * '''{{ msg('start-date') }}''': {% verbatim %}{{#dateformat:{% endverbatim %}{{ event.start|date('Y-m-d H:i') }}}} ({{ event.displayTimezone }})
 * '''{{ msg('end-date') }}''': {% verbatim %}{{#dateformat:{% endverbatim %}{{ event.end|date('Y-m-d H:i') }}}}
 

--- a/app/Resources/views/events/show.html.twig
+++ b/app/Resources/views/events/show.html.twig
@@ -17,21 +17,22 @@
 
         {% include 'events/_metadata.html.twig' %}
 
-        {% set helpLink %}
+        {% set help_link %}
             <a href="https://meta.wikimedia.org/wiki/Special:MyLanguage/Event_Metrics#filtering-required"
                title="{{ msg('error-filters-desc-tooltip') }}">
                 <span class="glyphicon glyphicon-question-sign"></span>
             </a>
         {% endset %}
 
-        {% set hasFormErrors = false %}
+        {% set has_form_errors = false %}
         {% for formType, form in forms %}
             {% if not form.vars.valid %}
-                {% set hasFormErrors = true %}
+                {# twigcs use-var has_form_errors #}
+                {% set has_form_errors = true %}
             {% endif %}
         {% endfor %}
 
-        {% set eventProcessLink %}
+        {% set event_process_link %}
             <a href="#" class="event-process-link">
                 {% if event.updated %}{{ msg('update-data') }}{% else %}{{ msg('calculate-totals') }}{% endif %}
             </a>
@@ -42,7 +43,7 @@
                 <h3>{{ msg('error-filters-header') }}</h3>
                 <p>
                     {{ msg('error-filters-desc') }}
-                    {{ helpLink }}
+                    {{ help_link }}
                 </p>
                 <ul>
                     {% if isOnlyWikidata %}
@@ -59,12 +60,12 @@
                 </ul>
             </section>
 
-        {% elseif event.participants.count == 0 and ( wikisWithoutCats.count or event.wikiByDomain('www.wikidata') ) %}
+        {% elseif event.participants.count == 0 and (wikisWithoutCats.count or event.wikiByDomain('www.wikidata')) %}
             <section class="event-errorbox warn">
                 <h3>{{ msg('category-warning-header') }}</h3>
                 <p>
-                    {{ msg('category-warning-desc', [eventProcessLink])|raw }}
-                    {{ helpLink }}
+                    {{ msg('category-warning-desc', [event_process_link])|raw }}
+                    {{ help_link }}
                 </p>
                 <ul>
                     {% if wikisWithoutCats.count %}
@@ -72,7 +73,7 @@
                         {{ msg('error-filters-categories-missing') }}
                         {% set cats = [] %}
                         {% for noCatWiki in wikisWithoutCats %}
-                            {% set cats = cats|merge(['<strong>'~noCatWiki.domain~'</strong>']) %}
+                            {% set cats = cats|merge(['<strong>' ~ noCatWiki.domain ~ '</strong>']) %}
                         {% endfor %}
                         {{ cats|list_format|raw }}
                     </li>
@@ -87,20 +88,21 @@
                 </ul>
             </section>
 
-        {% elseif not event.updated and not event.hasJob and not hasFormErrors %}
+        {# twigcs use-var has_form_errors #}
+        {% elseif not event.updated and not event.hasJob and not has_form_errors %}
             {% if event.startUTC > date() %}
                 <section class="event-errorbox warn">
                     <h3>{{ msg('event-in-future') }}</h3>
                     <ul>
-                        {% set settingsLink %}
+                        {% set settings_link %}
                             <a href="{{ path('EditEvent', {'programId': program.id, 'eventId': event.id}) }}">{{ msg('settings') }}</a>
                         {% endset %}
-                        <li>{{ msg('event-in-future-details', [settingsLink|trim])|raw }}</li>
+                        <li>{{ msg('event-in-future-details', [settings_link|trim])|raw }}</li>
                     </ul>
                 </section>
             {% else %}
                 <div class="alert alert-success event-wiki-stats--empty">
-                    {{ msg('event-no-data', [eventProcessLink])|raw }}
+                    {{ msg('event-no-data', [event_process_link])|raw }}
                 </div>
             {% endif %}
         {% endif %}
@@ -108,26 +110,24 @@
         <section class="event-filters clearfix">
             {% for formType, form in forms %}
                 {% form_theme form 'blocks/forms.html.twig' %}
-                {% include ('events/_' ~ formType|lower ~ '.html.twig') %}
+                {% include 'events/_' ~ formType|lower ~ '.html.twig' %}
             {% endfor %}
         </section>
 
         {% if event.updated is not null %}
             <section class="event-stats clearfix">
-                {% set allEditsLink %}
+                {% set all_edits_link %}
                     &middot;
                     <a href="{{ path('Revisions', {'programId': program.id, 'eventId': event.id}) }}" class="event-export-btn">
                         {{ msg('view-all-edits') }}
                     </a>
                 {% endset %}
-                {{
-                    layout.statsBlock(
-                        event,
-                        'contributions',
-                        ['pages-created', 'pages-improved', 'edits', 'files-uploaded', 'byte-difference', 'items-created', 'items-improved'],
-                        allEditsLink
-                    )
-                }}
+                {{ layout.statsBlock(
+                    event,
+                    'contributions',
+                    ['pages-created', 'pages-improved', 'edits', 'files-uploaded', 'byte-difference', 'items-created', 'items-improved'],
+                    all_edits_link
+                ) }}
 
                 {{ layout.statsBlock(event, 'impact', ['pages-created-pageviews', 'pages-improved-pageviews-avg', 'pages-using-files-pageviews-avg', 'pages-using-files', 'file-usage']) }}
 

--- a/app/Resources/views/macros/layout.html.twig
+++ b/app/Resources/views/macros/layout.html.twig
@@ -39,7 +39,7 @@
         -#}</a>
     {% endif %}
     <a href="{% if deletable or isAdmin() %}{{ path('Delete' ~ model, params) }}{% endif %}"
-       class="{{ model|lower }}-action {{ model|lower }}-action__delete{% if not(deletable) and not(isAdmin()) %} disabled{% endif %} text-danger"
+       class="{{ model|lower }}-action {{ model|lower }}-action__delete{% if not (deletable) and not (isAdmin()) %} disabled{% endif %} text-danger"
        data-title="{{ object.displayTitle }}" data-model="{{ model|lower }}"
        title="{{ msg('delete') }}">{#-
         -#}<span class="glyphicon glyphicon-trash"></span>{#-

--- a/app/Resources/views/programs/_form.html.twig
+++ b/app/Resources/views/programs/_form.html.twig
@@ -22,7 +22,7 @@
 <fieldset class="program__organizers">
     {# The organizer currently viewing the program cannot remove or rename themself. #}
     {% for organizer in form.organizers %}
-        {% set isViewingOrganizer = organizer.vars.value == logged_in_user().username %}
+        {% set is_viewing_organizer = organizer.vars.value == logged_in_user().username %}
 
         <div class="form-group organizer-row">
             {% if loop.index == 1 %}
@@ -31,10 +31,10 @@
                 <div class="col-sm-2"></div>
             {% endif %}
             <div class="col-sm-8{% if form_errors(organizer) %} has-error{% endif %}">
-                {{ form_widget(organizer, {'attr': {'class': 'user-input', 'readonly': isViewingOrganizer}}) }}
+                {{ form_widget(organizer, {'attr': {'class': 'user-input', 'readonly': is_viewing_organizer}}) }}
             </div>
             <div class="col-sm-2">
-                <button type="button" class="btn btn-default remove-organizer"{% if isViewingOrganizer %} disabled="disabled"{% endif %}>
+                <button type="button" class="btn btn-default remove-organizer"{% if is_viewing_organizer %} disabled="disabled"{% endif %}>
                     {{ msg('remove') }}
                 </button>
             </div>

--- a/app/Resources/views/programs/index.html.twig
+++ b/app/Resources/views/programs/index.html.twig
@@ -17,7 +17,7 @@
         </div>
 
         {% if programs|length < 1 %}
-            <div class="text-center">{{  msg('no-programs') }}</div>
+            <div class="text-center">{{ msg('no-programs') }}</div>
         {% else %}
             <table class="table em-table programs-list">
                 <thead>

--- a/app/Resources/views/programs/show.html.twig
+++ b/app/Resources/views/programs/show.html.twig
@@ -27,16 +27,16 @@
             </h1>
             <div class="programs-organizers">
                 {{ msg('organizers') }}:
-                {% set userLinks = [] %}
+                {% set user_links = [] %}
                 {% for username in program.organizerNames %}
-                    {% set userLinks = userLinks|merge(['<a target="_blank" href="https://meta.wikimedia.org/wiki/User:'~username~'">'~username~'</a>']) %}
+                    {% set user_links = user_links|merge(['<a target="_blank" href="https://meta.wikimedia.org/wiki/User:' ~ username ~ '">' ~ username ~ '</a>']) %}
                 {% endfor %}
-                {{ userLinks|list_format|raw }}
+                {{ user_links|list_format|raw }}
             </div>
         </div>
 
         {% if program.events|length < 1 %}
-            <div class="text-center">{{  msg('no-events') }}</div>
+            <div class="text-center">{{ msg('no-events') }}</div>
         {% else %}
             <table class="table em-table events-list">
                 <thead>
@@ -64,10 +64,10 @@
                             <td class="sort-entry--event" data-value="{{ event.title }}">
                                 <a href="{{ path('Event', {'programId': program.id, 'eventId': event.id}) }}">{{ bdi(event.displayTitle) }}</a>
                             </td>
-                            {% set numParticipants = event.numParticipants %}
+                            {% set num_participants = event.numParticipants %}
                             {% if isOrganizer %}
                                 <td class="text-nowrap">
-                                    {{ layout.actionButtons('Event', event, {'programId': program.id, 'eventId': event.id}, numParticipants == 0) }}
+                                    {{ layout.actionButtons('Event', event, {'programId': program.id, 'eventId': event.id}, num_participants == 0) }}
                                 </td>
                             {% endif %}
                             {% for metric in visibleMetrics if metrics[metric] is defined %}

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "wikimedia/toolforge-bundle": "^0.13"
     },
     "require-dev": {
+        "allocine/twigcs": "^3.1",
         "dms/phpunit-arraysubset-asserts": "^0.1.0",
         "doctrine/doctrine-fixtures-bundle": "^3.0",
         "johnkary/phpunit-speedtrap": "^3.0",
@@ -77,6 +78,7 @@
             "./bin/console lint:yaml ./app/config",
             "./bin/console lint:yaml .travis.yml",
             "./vendor/bin/phpcs -s .",
+            "./vendor/bin/twigcs app/Resources/views/",
             "./vendor/bin/minus-x check ."
         ],
         "docs": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec29f4ab7bd2fe2e7ba7cfaf9c2f5de9",
+    "content-hash": "b9eb2c3cc40d225157c3633f86d991cf",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -3466,6 +3466,53 @@
     ],
     "packages-dev": [
         {
+            "name": "allocine/twigcs",
+            "version": "v3.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/allocine/twigcs.git",
+                "reference": "9894a01a34b22d49e8898f8584c72961c9ca0592"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/allocine/twigcs/zipball/9894a01a34b22d49e8898f8584c72961c9ca0592",
+                "reference": "9894a01a34b22d49e8898f8584c72961c9ca0592",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "pimple/pimple": "^3.0",
+                "symfony/console": "^2.7 || ^3.0 || ^4.0",
+                "symfony/finder": "^2.7 || ^3.0 || ^4.0",
+                "twig/twig": "^1.0 || ^2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.2 || ^6.5"
+            },
+            "bin": [
+                "bin/twigcs"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Allocine\\Twigcs\\": "src/",
+                    "Allocine\\Twigcs\\Tests\\": "tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "OwlyCode",
+                    "email": "tmaindron@gmail.com"
+                }
+            ],
+            "description": "Checkstyle automation for Twig",
+            "time": "2018-09-10T07:42:53+00:00"
+        },
+        {
             "name": "dms/phpunit-arraysubset-asserts",
             "version": "v0.1.0",
             "source": {
@@ -4602,6 +4649,56 @@
                 "xunit"
             ],
             "time": "2019-03-26T14:00:24+00:00"
+        },
+        {
+            "name": "pimple/pimple",
+            "version": "v3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/silexphp/Pimple.git",
+                "reference": "9e403941ef9d65d20cba7d54e29fe906db42cf32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/silexphp/Pimple/zipball/9e403941ef9d65d20cba7d54e29fe906db42cf32",
+                "reference": "9e403941ef9d65d20cba7d54e29fe906db42cf32",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "psr/container": "^1.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Pimple": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Pimple, a simple Dependency Injection Container",
+            "homepage": "http://pimple.sensiolabs.org",
+            "keywords": [
+                "container",
+                "dependency injection"
+            ],
+            "time": "2018-01-21T07:42:36+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",


### PR DESCRIPTION
There is one bug affecting us with setting variables in a loop, see
https://github.com/allocine/twigcs/issues/35. This can be avoided
by adding a {# twigcs use-var my_var #} comment above the offending
line.