### PR TITLE
Show error on participants panel for any Wikidata event

### DIFF
--- a/app/Resources/views/events/_participants.html.twig
+++ b/app/Resources/views/events/_participants.html.twig
@@ -82,7 +82,7 @@
 {% set collapsed = event.updated != null %}
 {% set panel_desc = '' %}
 {# Here we use event.participants.count, ensuring it's the number of manually entered participants (and not derived). #}
-{% if event.participants.count == 0 and isOnlyWikidata %}
+{% if event.participants.count == 0 and event.wikiByDomain('www.wikidata') %}
     {% set panel_desc = msg('error-filters-wikidata-panel') ~ ' <span class="error glyphicon glyphicon-asterisk"></span>' %}
 {% elseif not filtersMissing and event.participants.count == 0 and wikisWithoutCats.count %}
     {% set panel_desc = msg('no-participants') ~ ' <span class="warn glyphicon glyphicon-warning-sign"></span>' %}


### PR DESCRIPTION
Change from only showing the 'required for Wikidata' message when
Wikidata is the only wiki, to showing it whenever there are no
participants and Wikidata is any one of the wikis.

Bug: T218340