### PR TITLE
PageviewsRepository: introduce HTTP retries and timeouts

### DIFF
--- a/src/AppBundle/Repository/EventWikiRepository.php
+++ b/src/AppBundle/Repository/EventWikiRepository.php
@@ -290,7 +290,7 @@ class EventWikiRepository extends Repository
             return 0;
         }
 
-        $pageviewsRepo = new PageviewsRepository();
+        $pageviewsRepo = $this->getPageviewsRepository();
         $recentDayCount = Event::AVAILABLE_METRICS['pages-improved-pageviews-avg'];
         $end = new DateTime('yesterday midnight');
         $pageviews = 0;
@@ -540,7 +540,7 @@ class EventWikiRepository extends Repository
         }
 
         $dbName = $this->getDbNameFromDomain($wiki->getDomain());
-        $pageviewsRepo = new PageviewsRepository();
+        $pageviewsRepo = $this->getPageviewsRepository();
         $avgPageviewsOffset = Event::AVAILABLE_METRICS['pages-improved-pageviews-avg'];
         $pages = $this->getPageTitles($dbName, $wiki->getPagesCreated(), true, true);
         $start = $wiki->getEvent()->getStartUTC();
@@ -681,7 +681,7 @@ class EventWikiRepository extends Repository
         }
 
         $dbName = $this->getDbNameFromDomain($wiki->getDomain());
-        $pageviewsRepo = new PageviewsRepository();
+        $pageviewsRepo = $this->getPageviewsRepository();
         $avgPageviewsOffset = Event::AVAILABLE_METRICS['pages-improved-pageviews-avg'];
         $pages = $this->getPageTitles($dbName, $wiki->getPagesImproved(), true, true);
         $start = $wiki->getEvent()->getStartUTC();
@@ -713,5 +713,16 @@ class EventWikiRepository extends Repository
         }
 
         return $data;
+    }
+
+    /**
+     * Creates and initializes a pageviews repository
+     * @return PageviewsRepository
+     */
+    private function getPageviewsRepository(): PageviewsRepository
+    {
+        $repo = new PageviewsRepository();
+        $repo->setLogger($this->log);
+        return $repo;
     }
 }

--- a/src/AppBundle/Service/EventProcessor.php
+++ b/src/AppBundle/Service/EventProcessor.php
@@ -263,6 +263,7 @@ class EventProcessor
         /** @var EventWikiRepository $ewRepo */
         $ewRepo = $this->entityManager->getRepository('Model:EventWiki');
         $ewRepo->setContainer($this->container);
+        $ewRepo->setLogger($this->logger);
 
         $start = $this->event->getStartUTC();
         $pageviewsCreatedTotal = 0;
@@ -348,6 +349,7 @@ class EventProcessor
         /** @var EventWikiRepository $ewRepo */
         $ewRepo = $this->entityManager->getRepository('Model:EventWiki');
         $ewRepo->setContainer($this->container);
+        $ewRepo->setLogger($this->logger);
 
         /** @var bool $saveEventStats Whether or not EventWikiStats are being saved. */
         $saveEventStats = false;


### PR DESCRIPTION
Prevent temporary network glitches from slowing down the process unduly.
At the same time, retry in case the problem was a one-off.

Bug: T219897