### PR TITLE
Disallow access to reports during an update

### DIFF
--- a/app/Resources/views/events/_header.html.twig
+++ b/app/Resources/views/events/_header.html.twig
@@ -36,7 +36,7 @@
                     </button>
                 {% endif %}
                 <div class="btn-group">
-                    <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <button type="button" class="btn btn-primary dropdown-toggle event-export-btn" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         {{ msg('event-download-reports') }} <span class="caret"></span>
                     </button>
                     <ul class="dropdown-menu dropdown-menu-right">

--- a/src/AppBundle/EventSubscriber/EventDataSubscriber.php
+++ b/src/AppBundle/EventSubscriber/EventDataSubscriber.php
@@ -53,8 +53,11 @@ class EventDataSubscriber implements EventSubscriberInterface
             return;
         }
 
-        // Redirect to event page if statistics have not yet been generated.
-        if (null === $controller->getEvent()->getUpdated()) {
+        /** @var Event $event */
+        $emEvent = $controller->getEvent();
+
+        // Redirect to event page if statistics have not yet been generated, or if a job is currently running.
+        if (null === $emEvent->getUpdated() || ($emEvent->hasJob() && $emEvent->getJob()->isBusy())) {
             $redirectUrl = $this->router->generate('Event', [
                 'programId' => $controller->getProgram()->getId(),
                 'eventId' => $controller->getEvent()->getId(),

--- a/tests/AppBundle/Controller/DatabaseAwareWebTestCase.php
+++ b/tests/AppBundle/Controller/DatabaseAwareWebTestCase.php
@@ -199,4 +199,22 @@ abstract class DatabaseAwareWebTestCase extends EventMetricsTestCase
         }
         return $this->fixtureLoader;
     }
+
+    /**
+     * Check that each given route returns a the given response code.
+     * @param string[] $routes
+     * @param int $expectedResponse
+     */
+    public function assertRoutesResponses(array $routes, int $expectedResponse): void
+    {
+        foreach ($routes as $route) {
+            $this->client->request('GET', $route);
+            $actualResponse = $this->client->getResponse()->getStatusCode();
+            static::assertEquals(
+                $actualResponse,
+                $expectedResponse,
+                "Failed: $route expected $expectedResponse response but got $actualResponse"
+            );
+        }
+    }
 }

--- a/tests/AppBundle/Controller/EventDataControllerTest.php
+++ b/tests/AppBundle/Controller/EventDataControllerTest.php
@@ -34,6 +34,36 @@ class EventDataControllerTest extends DatabaseAwareWebTestCase
     }
 
     /**
+     * Assert response codes are correct when a job is currently running.
+     */
+    public function testResponses(): void
+    {
+        /** @var Event $event */
+        $event = $this->entityManager
+            ->getRepository('Model:Event')
+            ->findOneBy(['title' => 'Oliver_and_Company']);
+
+        // Pretend the Event has been updated.
+        $event->setUpdated(new \DateTime());
+
+        // Create Job and set it to the started state.
+        $job = new Job($event);
+        $job->setStatus(Job::STATUS_STARTED);
+        $this->entityManager->persist($job);
+        $this->entityManager->flush();
+
+        $eventId = $event->getId();
+        $programId = $event->getProgram()->getId();
+
+        $this->assertRoutesResponses([
+            "/programs/$programId/events/$eventId/revisions",
+            "/programs/$programId/events/$eventId/summary",
+            "/programs/$programId/events/$eventId/pages-improved",
+            "/programs/$programId/events/$eventId/pages-created",
+        ], 302);
+    }
+
+    /**
      * Revisions page.
      */
     public function testRevisions(): void


### PR DESCRIPTION
This check used to exist but somehow got removed. The idea
is that you don't want to allow the user to run a report because
the update will change the page IDs that the report depends on.