### PR TITLE
Fetch pageviews asynchronously, max 100 per second

### DIFF
--- a/src/AppBundle/Repository/PageviewsRepository.php
+++ b/src/AppBundle/Repository/PageviewsRepository.php
@@ -6,11 +6,16 @@ namespace AppBundle\Repository;
 use DateInterval;
 use DateTime;
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Handler\CurlMultiHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
+use function GuzzleHttp\Promise\settle;
 
 /**
  * A PageviewsRepository is used to fetch data from the pageviews API.
@@ -21,163 +26,54 @@ class PageviewsRepository
     use LoggerAwareTrait;
 
     public const GRANULARITY_HOURLY = 'hourly';
-
     public const GRANULARITY_DAILY = 'daily';
-
     public const GRANULARITY_MONTHLY = 'monthly';
 
-    /** @var string YYYY-MM-DD format of the earliest data available in the Pageviews API. */
+    /** YYYY-MM-DD format of the earliest data available in the Pageviews API. */
     public const MINIMUM_START_DATE = '2015-07-01';
 
     private const REQUEST_TIMEOUT = 3;
-
     private const CONNECT_TIMEOUT = 1.5;
-
     private const RETRIES = 3;
+    private const REQUEST_DELAY = 100;
 
     /** @var string Base URL for the REST endpoint. */
     protected $endpointUrl = 'https://wikimedia.org/api/rest_v1/metrics/pageviews';
 
+    /** @var Client The GuzzleHttp client. */
+    private $client;
+
     public function __construct()
     {
+        $this->client = new Client([
+            'timeout' => self::REQUEST_TIMEOUT,
+            'connect_timeout' => self::CONNECT_TIMEOUT,
+            'delay' => self::REQUEST_DELAY,
+            'handler' => $this->getRetryHandler(),
+        ]);
         $this->logger = new NullLogger();
     }
 
     /**
-     * Given a Mediawiki article and a date range, returns a daily timeseries of its pageview counts.
-     * @link https://wikimedia.org/api/rest_v1/#!/Pageviews_data/get_metrics_pageviews_per_article_project_access_agent_article_granularity_start_end
-     * @param string $domain
-     * @param string $article Page title with underscores. Will be URL-encoded.
-     * @param string $granularity The time unit for the response data, either GRANULARITY_DAILY or GRANULARITY_MONTHLY.
-     * @param DateTime $startTime
-     * @param DateTime $endTime
-     * @return string[][]
+     * Retry handler for the Guzzle Client.
+     * @return HandlerStack
      */
-    public function getPerArticle(
-        string $domain,
-        string $article,
-        string $granularity,
-        DateTime $startTime,
-        DateTime $endTime
-    ) : array {
-        $article = urlencode($article);
-        $dateFormat = 'Ymd';
-        $start = $startTime->format($dateFormat);
-        $end = $endTime->format($dateFormat);
-        $url = $this->endpointUrl."/per-article/$domain/all-access/user/$article/$granularity/$start/$end";
-        return $this->fetch($url);
-    }
-
-    /**
-     * Get the sum of daily pageviews for the given article and date range.
-     * @param string $domain
-     * @param string $pageTitle
-     * @param DateTime $start
-     * @param DateTime $end
-     * @param int|null $avgDaysOffset Specifies the number of days over which to compute the daily average pageviews.
-     * @see PageviewsRepository::getPageviewsPerArticle() if you only need the average.
-     * @return int|int[]|null Sum of pageviews, or [sum of pageviews, average],
-     *   or null if no data was found (could be new article, 404, etc.).
-     */
-    public function getPageviewsPerArticle(
-        string $domain,
-        string $pageTitle,
-        DateTime $start,
-        DateTime $end,
-        ?int $avgDaysOffset = null
-    ) {
-        $pageviewsInfo = $this->getPerArticle(
-            $domain,
-            $pageTitle,
-            PageviewsRepository::GRANULARITY_DAILY,
-            $start,
-            $end
-        );
-
-        if (!isset($pageviewsInfo['items'])) {
-            return null;
-        }
-
-        $avgOffsetDate = (clone $end)->sub(new DateInterval('P'.(int)$avgDaysOffset.'D'));
-        $lastAvgDate = null;
-        $pageviews = 0;
-        $recentPageviews = 0;
-
-        foreach (array_reverse($pageviewsInfo['items']) as $item) {
-            $date = DateTime::createFromFormat('YmdHi', $item['timestamp'].'00');
-            if ($date >= $avgOffsetDate) {
-                $recentPageviews += $item['views'];
-                $lastAvgDate = $date;
-            }
-            $pageviews += $item['views'];
-        }
-
-        if (is_int($avgDaysOffset)) {
-            if (null === $lastAvgDate) {
-                // No recent pageviews, so average is 0.
-                return [$pageviews, 0];
-            }
-            $numDays = $end->diff($lastAvgDate)->days + 1; // +1 because dates are inclusive.
-            return [$pageviews, (int)round($recentPageviews / $numDays)];
-        }
-
-        return $pageviews;
-    }
-
-    /**
-     * Get the sum of daily pageviews for the given article and date range.
-     * @param string $domain
-     * @param string $pageTitle
-     * @param int $offset Specifies the number of days from today over which to compute the daily average pageviews.
-     * @return int|null
-     */
-    public function getAvgPageviewsPerArticle(
-        string $domain,
-        string $pageTitle,
-        int $offset = 30
-    ) : ?int {
-        $end = new DateTime('yesterday midnight');
-        $start = (clone $end)->sub(new DateInterval('P'.$offset.'D'));
-        return $this->getPageviewsPerArticle($domain, $pageTitle, $start, $end, $offset)[1] ?? null;
-    }
-
-    /**
-     * Given a date range, returns a timeseries of pageview counts. You can filter by project, access method and/or
-     * agent type. You can choose between daily and hourly granularity as well.
-     * @link https://wikimedia.org/api/rest_v1/#!/Pageviews_data/get_metrics_pageviews_aggregate_project_access_agent_granularity_start_end
-     * @param string $granularity The time unit for the response data, one of this class' GRANULARITY_* constants.
-     * @param DateTime $startTime The first hour/day/month to include.
-     * @param DateTime $endTime The last hour/day/month to include.
-     * @param string|null $domain The project to query. If not given, pages views on all projects will be returned.
-     * @return string[][]
-     */
-    public function getAggregate(
-        string $granularity,
-        DateTime $startTime,
-        DateTime $endTime,
-        ?string $domain = null
-    ) : array {
-        $project = $domain ?? 'all-projects';
-        $dateFormat = 'Ymdh';
-        $start = $startTime->format($dateFormat);
-        $end = $endTime->format($dateFormat);
-        $url = $this->endpointUrl."/aggregate/$project/all-access/$granularity/user/$start/$end";
-        return $this->fetch($url);
-    }
-
-    /**
-     * Fetch and decode an API response.
-     * @param string $url
-     * @return string[][]
-     */
-    protected function fetch(string $url) : array
+    private function getRetryHandler(): HandlerStack
     {
-        $handlerStack = HandlerStack::create();
-        $handlerStack->push(Middleware::retry(function ($retry, $request, $value, $reason) use ($url) {
-            if (null !== $value) {
+        $handlerStack = HandlerStack::create(new CurlMultiHandler());
+        $handlerStack->push(Middleware::retry(function (
+            int $retry,
+            Request $request,
+            ?Response $response,
+            ?RequestException $exception
+        ) {
+            if (null !== $response) {
                 // Request succeeded
                 return false;
             }
+
+            $url = $request->getUri()->getPath();
+            $reason = $exception ? $exception->getMessage() : 'Unknown';
 
             if ($retry < self::RETRIES) {
                 $this->logger->notice(
@@ -195,32 +91,148 @@ class PageviewsRepository
             $this->logger->error(
                 'Fetching {url} failed after {retry} retries: {reason}',
                 [
-                    'retry' => $retry,
                     'url' => $url,
+                    'retry' => $retry,
                     'reason' => $reason,
                 ]
             );
+
             return false;
         }));
 
-        $client = new Client();
-        try {
-            $response = $client->get(
-                $url,
-                [
-                    'timeout' => self::REQUEST_TIMEOUT,
-                    'connect_timeout' => self::CONNECT_TIMEOUT,
-                    'handler' => $handlerStack,
-                ]
-            );
-        } catch (ClientException $exception) {
-            return [];
+        return $handlerStack;
+    }
+
+    /**
+     * Get the combined pageviews, and optionally average pageviews, of the given articles.
+     * @see PageviewsRepository::getAvgPageviews() if you only need an average.
+     * @param string $domain
+     * @param string[] $pageTitles
+     * @param DateTime $start
+     * @param DateTime $end
+     * @param int|null $avgDaysOffset Specifies the number of days over which to compute the daily average pageviews.
+     * @return int|int[] Sum of pageviews, or [sum of pageviews, average] if $avgDaysOffset is given.
+     */
+    public function getPageviews(
+        string $domain,
+        array $pageTitles,
+        DateTime $start,
+        DateTime $end,
+        ?int $avgDaysOffset = null
+    ) {
+        $promises = [];
+
+        foreach ($pageTitles as $pageTitle) {
+            $promises[] = $this->get($domain, $pageTitle, self::GRANULARITY_DAILY, $start, $end);
         }
-        if (200 !== $response->getStatusCode()) {
-            // Discard errors (such as monthly granularity with no full month specified).
-            return [];
+        $responses = settle($promises)->wait();
+
+        $totalPageviews = 0;
+        $totalAvgPageviews = 0;
+
+        $avgOffsetDate = $avgDaysOffset
+            ? (clone $end)->sub(new DateInterval('P'.(int)$avgDaysOffset.'D'))
+            : null;
+
+        foreach ($responses as $response) {
+            if ('fulfilled' !== $response['state']) {
+                // Do nothing, API didn't have data most likely.
+            } else {
+                /** @var Response $value */
+                $value = $response['value'];
+                $result = json_decode($value->getBody()->getContents(), true);
+
+                if ($avgOffsetDate) {
+                    [$pageviews, $avgPageviews] = $this->processResponse($result, $end, $avgOffsetDate);
+                    $totalPageviews += $pageviews;
+                    $totalAvgPageviews += $avgPageviews;
+                } else {
+                    $totalPageviews += $this->processResponse($result, $end);
+                }
+            }
         }
-        $responseJson = $response->getBody()->read($response->getBody()->getSize());
-        return json_decode($responseJson, true);
+
+        if (null !== $avgDaysOffset) {
+            return [$totalPageviews, $totalAvgPageviews];
+        } else {
+            return $totalPageviews;
+        }
+    }
+
+    /**
+     * Get the sum of the average of pageviews for the given articles.
+     * @param string $domain
+     * @param string[] $pageTitles
+     * @param int $offset Specifies the number of days from today over which to compute the daily average pageviews.
+     * @return int
+     */
+    public function getAvgPageviews(string $domain, array $pageTitles, int $offset = 30): int
+    {
+        $end = new DateTime('yesterday midnight');
+        $start = (clone $end)->sub(new DateInterval('P'.$offset.'D'));
+        return $this->getPageviews($domain, $pageTitles, $start, $end, $offset)[1];
+    }
+
+    /**
+     * Given a Mediawiki article and a date range, returns a daily timeseries of its pageview counts.
+     * @link https://wikimedia.org/api/rest_v1/#!/Pageviews_data/get_metrics_pageviews_per_article_project_access_agent_article_granularity_start_end
+     * @param string $domain
+     * @param string $article Page title with underscores. Will be URL-encoded.
+     * @param string $granularity The time unit for the response data, either GRANULARITY_DAILY or GRANULARITY_MONTHLY.
+     * @param DateTime $startTime
+     * @param DateTime $endTime
+     * @return PromiseInterface
+     */
+    public function get(
+        string $domain,
+        string $article,
+        string $granularity,
+        DateTime $startTime,
+        DateTime $endTime
+    ) : PromiseInterface {
+        $article = urlencode($article);
+        $dateFormat = 'Ymd';
+        $start = $startTime->format($dateFormat);
+        $end = $endTime->format($dateFormat);
+        $url = $this->endpointUrl."/per-article/$domain/all-access/user/$article/$granularity/$start/$end";
+        return $this->client->getAsync($url);
+    }
+
+    /**
+     * Parse the given Pageviews API response, returning the sum, and average if requested.
+     * @param array[][] $response
+     * @param DateTime $end
+     * @param DateTime|null $avgOffsetDate Date from which to compute average.
+     * @return int|int[] Sum of pageviews, or [sum of pageviews, average] if $avgOffsetDate is given.
+     */
+    private function processResponse(array $response, DateTime $end, ?DateTime $avgOffsetDate = null)
+    {
+        if (!isset($response['items'])) {
+            return 0;
+        }
+
+        $lastAvgDate = null;
+        $pageviews = 0;
+        $recentPageviews = 0;
+
+        foreach (array_reverse($response['items']) as $item) {
+            $date = DateTime::createFromFormat('YmdHi', $item['timestamp'].'00');
+            if ($avgOffsetDate && $date >= $avgOffsetDate) {
+                $recentPageviews += $item['views'];
+                $lastAvgDate = $date;
+            }
+            $pageviews += $item['views'];
+        }
+
+        if (null !== $avgOffsetDate) {
+            if (null === $lastAvgDate) {
+                // No recent pageviews, so average is 0.
+                return [$pageviews, 0];
+            }
+            $numDays = $end->diff($lastAvgDate)->days + 1; // +1 because dates are inclusive.
+            return [$pageviews, (int)round($recentPageviews / $numDays)];
+        }
+
+        return $pageviews;
     }
 }

--- a/tests/AppBundle/Repository/PageviewsRepositoryTest.php
+++ b/tests/AppBundle/Repository/PageviewsRepositoryTest.php
@@ -21,39 +21,7 @@ class PageviewsRepositoryTest extends EventMetricsTestCase
     }
 
     /**
-     * @covers \AppBundle\Repository\PageviewsRepository::getPerArticle()
-     */
-    public function testPerArticle():void
-    {
-        $pageviews = $this->repo->getPerArticle(
-            'zh.wikipedia',
-            '一期一會',
-            PageviewsRepository::GRANULARITY_DAILY,
-            new \DateTime('2019-01-01'),
-            new \DateTime('2019-01-02')
-        );
-
-        static::assertEquals(['items' => [[
-            'project' => 'zh.wikipedia',
-            'article' => '一期一會',
-            'granularity' => 'daily',
-            'timestamp' => '2019010100',
-            'access' => 'all-access',
-            'agent' => 'user',
-            'views' => 281,
-        ], [
-            'project' => 'zh.wikipedia',
-            'article' => '一期一會',
-            'granularity' => 'daily',
-            'timestamp' => '2019010200',
-            'access' => 'all-access',
-            'agent' => 'user',
-            'views' => 255,
-        ]]], $pageviews);
-    }
-
-    /**
-     * @covers \AppBundle\Repository\PageviewsRepository::getPageviewsPerArticle()
+     * @covers \AppBundle\Repository\PageviewsRepository::getPageviews()
      */
     public function testPageviews(): void
     {
@@ -63,15 +31,22 @@ class PageviewsRepositoryTest extends EventMetricsTestCase
         // Raw total pageviews.
         static::assertEquals(
             361,
-            $this->repo->getPageviewsPerArticle('en.wikipedia', 'Domino_Park', $start, $end)
+            $this->repo->getPageviews('en.wikipedia', ['Domino_Park'], $start, $end)
         );
 
-        [$total, $avg] = $this->repo->getPageviewsPerArticle(
+        // Multiple pages.
+        static::assertEquals(
+            93059,
+            $this->repo->getPageviews('en.wikipedia', ['Cat', 'Dog'], $start, $end)
+        );
+
+        // With average.
+        [$total, $avg] = $this->repo->getPageviews(
             'en.wikipedia',
-            'Domino_Park',
+            ['Domino_Park'],
             $start,
             $end,
-            30
+            31
         );
 
         // First element should be the same as total pageviews.
@@ -84,12 +59,12 @@ class PageviewsRepositoryTest extends EventMetricsTestCase
         $end = new DateTime('2019-02-15');
 
         // This particular endpoint has gaps in the time series.
-        // getPageviewsPerArticle() should fill these in with zeros and give you the correct average.
+        // getPageviews() should fill these in with zeros and give you the correct average.
         // @see https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/wikidata/all-access/user/Q61506256/daily/20190201/20190215
         // @see https://wikitech.wikimedia.org/wiki/Analytics/AQS/Pageviews#Gotchas
         static::assertEquals(
             [12, 1], // 12 total pageviews, divided by 15 days = round(0.8) = 1 average pageview a day.
-            $this->repo->getPageviewsPerArticle('www.wikidata', 'Q61506256', $start, $end, 30)
+            $this->repo->getPageviews('www.wikidata', ['Q61506256'], $start, $end, 31)
         );
     }
 }


### PR DESCRIPTION
This only covers fetching of pageviews during a normal update.
The reports still need to be converted to be async.

PageviewsRepository::getAggregate() was removed as it is not used and
unlikely to be used in the future.

Bug: T217911